### PR TITLE
Fix team repos

### DIFF
--- a/internal/engine/remote.go
+++ b/internal/engine/remote.go
@@ -553,58 +553,6 @@ type GraplQLTeams struct {
 	} `json:"errors"`
 }
 
-const listAllTeamsReposInOrg = `
-query listAllTeamsReposInOrg($orgLogin: String!, $teamSlug: String!, $endCursor: String) {
-  organization(login: $orgLogin) {
-    team(slug: $teamSlug) {
-       repositories(first: 100, after: $endCursor) {
-        edges {
-          permission
-          node {
-            name
-          }
-        }
-        pageInfo {
-          hasNextPage
-          endCursor
-        }
-        totalCount
-      }
-    }
-  }
-}
-`
-
-type GraplQLTeamsRepos struct {
-	Data struct {
-		Organization struct {
-			Team struct {
-				Repository struct {
-					Edges []struct {
-						Permission string
-						Node       struct {
-							Name string
-						}
-					} `json:"edges"`
-					PageInfo struct {
-						HasNextPage bool
-						EndCursor   string
-					} `json:"pageInfo"`
-					TotalCount int `json:"totalCount"`
-				} `json:"repositories"`
-			} `json:"team"`
-		}
-	}
-	Errors []struct {
-		Path       []interface{} `json:"path"`
-		Extensions struct {
-			Code         string
-			ErrorMessage string
-		} `json:"extensions"`
-		Message string
-	} `json:"errors"`
-}
-
 func (g *GoliacRemoteImpl) loadAppIds(ctx context.Context) (map[string]int, error) {
 	logrus.Debug("loading appIds")
 	type Installation struct {


### PR DESCRIPTION
This pull request includes significant changes to the `GoliacRemoteImpl` class to enhance the way team repositories are loaded both concurrently and non-concurrently. The changes switch from GraphQL to REST API call, because GraphQL cannot give IMMEDIATE/direct teams and member roles.

Enhancements to repository loading logic:

* [`internal/engine/remote.go`](diffhunk://#diff-d958c8f043d246d54ff3885f741b2d145e6c2d9df2e2ec00c7ed941e4a1deccbL745-R793): Updated `loadTeamReposNonConcurrently` and `loadTeamReposConcurrently` methods to invert the map from repositories to teams, improving the organization and retrieval of data. [[1]](diffhunk://#diff-d958c8f043d246d54ff3885f741b2d145e6c2d9df2e2ec00c7ed941e4a1deccbL745-R793) [[2]](diffhunk://#diff-d958c8f043d246d54ff3885f741b2d145e6c2d9df2e2ec00c7ed941e4a1deccbL787-R886)

Update to team repository data fetching:

* [`internal/engine/remote.go`](diffhunk://#diff-d958c8f043d246d54ff3885f741b2d145e6c2d9df2e2ec00c7ed941e4a1deccbL787-R886): Replaced the GraphQL API call with a REST API call in the `loadTeamRepos` method to fetch team repository data, and added a new `TeamsRepoResponse` struct to handle the response.

Adjustments to tests:

* [`internal/engine/remote_test.go`](diffhunk://#diff-dc5a513a31e66552a09b381e2544d74c4d274ffbcf64f1c5033ef9c7de88edd9R11-R14): Added the `strings` import and updated the `MockGithubClient` to simulate the REST API response for repository teams. [[1]](diffhunk://#diff-dc5a513a31e66552a09b381e2544d74c4d274ffbcf64f1c5033ef9c7de88edd9R11-R14) [[2]](diffhunk://#diff-dc5a513a31e66552a09b381e2544d74c4d274ffbcf64f1c5033ef9c7de88edd9R396-R409)
* [`internal/engine/remote_test.go`](diffhunk://#diff-dc5a513a31e66552a09b381e2544d74c4d274ffbcf64f1c5033ef9c7de88edd9L438-R455): Modified tests in `TestRemoteRepository` to align with the new logic and data structure, ensuring correct validation of repository permissions and team-repo mappings. [[1]](diffhunk://#diff-dc5a513a31e66552a09b381e2544d74c4d274ffbcf64f1c5033ef9c7de88edd9L438-R455) [[2]](diffhunk://#diff-dc5a513a31e66552a09b381e2544d74c4d274ffbcf64f1c5033ef9c7de88edd9L454-R468)