### PR TITLE
Version in cli

### DIFF
--- a/cmd/goliac/main.go
+++ b/cmd/goliac/main.go
@@ -176,14 +176,14 @@ The adminteam is your current team that contains Github administrator`,
 				newRepoSuggestion := filepath.Dir(directory)
 				cwd, err := os.Getwd()
 				if err == nil {
-					newRepoSuggestion = filepath.Dir(filepath.Join(cwd, directory))
+					newRepoSuggestion = filepath.Base(filepath.Join(cwd, directory))
 				}
-				newRepoSuggestion = config.Config.GithubServer + "/" + config.Config.GithubAppOrganization + "/" + newRepoSuggestion
+				newRepoSuggestion = "https://github.com/" + config.Config.GithubAppOrganization + "/" + newRepoSuggestion
 				fmt.Printf(`Scaffold directory (%s) created
 Now you can push this directory as a new repository to Github, like:
 - check the validity of the directory:
    goliac verify %s
-- create a new repository %s on Github
+- create a new repository '%s' on Github
 - push this directory to the new repository:
    cd %s
    git init --initial-branch=main

--- a/cmd/goliac/main.go
+++ b/cmd/goliac/main.go
@@ -224,6 +224,14 @@ any changes from the teams Git repository to Github.`,
 		},
 	}
 
+	versioncmd := &cobra.Command{
+		Use:   "version",
+		Short: "Return the version of the goliac CLI",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(config.GoliacBuildVersion)
+		},
+	}
+
 	rootCmd := &cobra.Command{
 		Use:   "goliac",
 		Short: "A CLI for the goliac organization",
@@ -238,6 +246,7 @@ Either local directory, or remote git repository`,
 	rootCmd.AddCommand(postSyncUsersCmd)
 	rootCmd.AddCommand(scaffoldcmd)
 	rootCmd.AddCommand(servecmd)
+	rootCmd.AddCommand(versioncmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
This pull request includes several changes to the `cmd/goliac/main.go` file, focusing on improving user experience and adding new functionality. The most important changes include updating the repository suggestion format and adding a new command to display the version of the CLI.

Enhancements to user experience:

* Updated the repository suggestion format to use `filepath.Base` instead of `filepath.Dir` and changed the URL format to "https://github.com/" followed by the organization and repository name. (`cmd/goliac/main.go`)

New functionality:

* Added a new `version` command to the CLI to display the current version of the `goliac` CLI. (`cmd/goliac/main.go`) [[1]](diffhunk://#diff-df68a1b048715f7eacc4fe182677593f75eebc9ad69fbd2dc7ea137af065924fR227-R234) [[2]](diffhunk://#diff-df68a1b048715f7eacc4fe182677593f75eebc9ad69fbd2dc7ea137af065924fR249)