### PR TITLE
discard users in SAML discovery, that do not have yet accepted an invitation

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -47,3 +47,10 @@ This error is happening if a team does not have enough owners.
 Indeed a team must have at least 2 owners to be able to review and merge PRs (and the only owner cannot approve its own PRs).
 
 As an admin you should add more owners to the team.
+
+# Goliac is trying to add a user that is no longer part of the organization
+
+Maybe the user is still part of the SSO group, but not part of the organization anymore.
+The best way to solve it is to remove the user from the SSO group:
+
+As an admin try to go to `https://github.com/orgs/<your organization>/people/<github user>/sso` and revoke the user from the SSO group.

--- a/internal/goliac_test.go
+++ b/internal/goliac_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -422,6 +423,9 @@ func (c *GitHubClientMock) QueryGraphQLAPI(ctx context.Context, query string, va
 }
 
 func (c *GitHubClientMock) CallRestAPI(ctx context.Context, endpoint, method string, body map[string]interface{}) ([]byte, error) {
+	if strings.HasSuffix(endpoint, "/invitations") {
+		return []byte(`[]`), nil
+	}
 	return nil, nil
 }
 func (c *GitHubClientMock) GetAccessToken(context.Context) (string, error) {


### PR DESCRIPTION
we list invitations to check users login (not email) that are still pending