### PR TITLE
bugfix: delete_branch_on_merge on goliac_teams

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -452,6 +452,7 @@ By default Goliac works by polling the state of the goliac teams GitHub reposito
 To do so, you need to update the GitHub App configuration:
 - in General:
   - enable the active Webhook
+  - change the Content-Type for `application/json`
   - set a webhook secret
   - set the webhook URL to be able to reach `http://GOLIAC_SERVER_HOST:GOLIAC_SERVER_PORT/webhook`
 - in Subscribe to events

--- a/internal/engine/goliac_reconciliator.go
+++ b/internal/engine/goliac_reconciliator.go
@@ -422,6 +422,7 @@ func (r *GoliacReconciliatorImpl) reconciliateRepositories(ctx context.Context, 
 	teamsRepo.Spec.Writers = []string{r.repoconfig.AdminTeam}
 	teamsRepo.Spec.Readers = []string{}
 	teamsRepo.Spec.IsPublic = false
+	teamsRepo.Spec.DeleteBranchOnMerge = true
 	localRepositories[teamsreponame] = teamsRepo
 
 	for reponame, lRepo := range localRepositories {

--- a/internal/github_webhook_server.go
+++ b/internal/github_webhook_server.go
@@ -150,6 +150,7 @@ func (s *GithubWebhookServerImpl) handlePushEvent(w http.ResponseWriter, body []
 		s.callback()
 	} else {
 		http.Error(w, "Parse push event: wrong branch", http.StatusBadRequest)
+		return
 	}
 
 	w.WriteHeader(http.StatusOK)

--- a/internal/goliac_test.go
+++ b/internal/goliac_test.go
@@ -516,7 +516,7 @@ func (e *GoliacRemoteExecutorMock) Repositories(ctx context.Context) map[string]
 				"archived":               false,
 				"private":                true,
 				"allow_auto_merge":       false,
-				"delete_branch_on_merge": false,
+				"delete_branch_on_merge": true,
 				"allow_update_branch":    false,
 			},
 			ExternalUsers: map[string]string{},


### PR DESCRIPTION
- fix delete_branch_on_merge on goliac_teams
- fix webhook doc
- fix a superfluous response.WriteHeader call from github.com/Alayacare/goliac/internal.(*GithubWebhookServerImpl).handlePushEvent (github_webhook_server.go:155)