### PR TITLE
Rename repos

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,7 +9,7 @@ As a regular user, you want to be able to
 
 If you want to create a new team (like `foobar`), you need to create a PR with a `/teams/foobar/team.yaml` file:
 
-```
+```yaml
 apiVersion: v1
 kind: Team
 name: foobar
@@ -32,7 +32,7 @@ The users name used are the one defined in the `/users` sub directories (like `a
 
 On a given team subdirectory you can create a repository definition via a yaml file (like `/teams/foobar/awesome-repository.yaml`):
 
-```
+```yaml
 apiVersion: v1
 kind: Repository
 name: awesome-repository
@@ -44,7 +44,7 @@ This will create a `awesome-repository` repository under your organization, that
 
 You can of course tweak that:
 
-```
+```yaml
 apiVersion: v1
 kind: Repository
 name: awesome-repository
@@ -67,6 +67,21 @@ In this last example:
 - the repository will delete the branch on merge
 - the repository allows to update the branch
 - other teams have write (`anotherteamA`, `anotherteamB`) or read (`anotherteamC`, `anotherteamD`) access
+
+## Renale a repository
+
+You need to add a `renameTo` to the repository, and Goliac will rename it (and update the `goliac-teams` repository):
+
+```yaml
+apiVersion: v1
+kind: Repository
+name: awesome-repository
+spec:
+  public: true
+  ...
+renameTo: anotherName
+```
+
 
 ## Archive a repository
 

--- a/internal/config/middleware.go
+++ b/internal/config/middleware.go
@@ -3,7 +3,6 @@ package config
 import (
 	"net/http"
 
-	negronilogrus "github.com/meatballhat/negroni-logrus"
 	"github.com/phyber/negroni-gzip/gzip"
 	"github.com/rs/cors"
 	"github.com/sirupsen/logrus"
@@ -24,7 +23,7 @@ func SetupGlobalMiddleware(handler http.Handler) http.Handler {
 	}
 
 	if Config.MiddlewareVerboseLoggerEnabled {
-		middleware := negronilogrus.NewMiddlewareFromLogger(logrus.StandardLogger(), "goliac")
+		middleware := NewMiddlewareFromLogger(logrus.StandardLogger(), logrus.DebugLevel, "goliac")
 
 		for _, u := range Config.MiddlewareVerboseLoggerExcludeURLs {
 			middleware.ExcludeURL(u)

--- a/internal/config/negronilogrus.go
+++ b/internal/config/negronilogrus.go
@@ -1,0 +1,183 @@
+package config
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/negroni"
+)
+
+type timer interface {
+	Now() time.Time
+	Since(time.Time) time.Duration
+}
+
+type realClock struct{}
+
+func (rc *realClock) Now() time.Time {
+	return time.Now()
+}
+
+func (rc *realClock) Since(t time.Time) time.Duration {
+	return time.Since(t)
+}
+
+// Middleware is a middleware handler that logs the request as it goes in and the response as it goes out.
+type Middleware struct {
+	// Logger is the log.Logger instance used to log messages with the Logger middleware
+	Logger *logrus.Logger
+	// Name is the name of the application as recorded in latency metrics
+	Name   string
+	Before func(*logrus.Entry, *http.Request, string) *logrus.Entry
+	After  func(*logrus.Entry, negroni.ResponseWriter, time.Duration, string) *logrus.Entry
+
+	logLevel     logrus.Level
+	logStarting  bool
+	logCompleted bool
+
+	clock timer
+
+	// Exclude URLs from logging
+	excludeURLs []string
+}
+
+// NewMiddleware returns a new *Middleware, yay!
+func NewMiddleware() *Middleware {
+	return NewCustomMiddleware(logrus.InfoLevel, &logrus.TextFormatter{}, "web")
+}
+
+// NewCustomMiddleware builds a *Middleware with the given level and formatter
+func NewCustomMiddleware(level logrus.Level, formatter logrus.Formatter, name string) *Middleware {
+	log := logrus.New()
+	log.Level = level
+	log.Formatter = formatter
+
+	return &Middleware{
+		Logger: log,
+		Name:   name,
+		Before: DefaultBefore,
+		After:  DefaultAfter,
+
+		logLevel:     level,
+		logStarting:  true,
+		logCompleted: true,
+		clock:        &realClock{},
+	}
+}
+
+// NewMiddlewareFromLogger returns a new *Middleware which writes to a given logrus logger.
+func NewMiddlewareFromLogger(logger *logrus.Logger, level logrus.Level, name string) *Middleware {
+	return &Middleware{
+		Logger: logger,
+		Name:   name,
+		Before: DefaultBefore,
+		After:  DefaultAfter,
+
+		logLevel:     level,
+		logStarting:  true,
+		logCompleted: true,
+		clock:        &realClock{},
+	}
+}
+
+// SetLogStarting accepts a bool to control the logging of "started handling
+// request" prior to passing to the next middleware
+func (m *Middleware) SetLogStarting(v bool) {
+	m.logStarting = v
+}
+
+// SetLogCompleted accepts a bool to control the logging of "completed handling
+// request" after returning from the next middleware
+func (m *Middleware) SetLogCompleted(v bool) {
+	m.logCompleted = v
+}
+
+// ExcludeURL adds a new URL u to be ignored during logging. The URL u is parsed, hence the returned error
+func (m *Middleware) ExcludeURL(u string) error {
+	if _, err := url.Parse(u); err != nil {
+		return err
+	}
+	m.excludeURLs = append(m.excludeURLs, u)
+	return nil
+}
+
+// ExcludedURLs returns the list of excluded URLs for this middleware
+func (m *Middleware) ExcludedURLs() []string {
+	return m.excludeURLs
+}
+
+func (m *Middleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	if m.Before == nil {
+		m.Before = DefaultBefore
+	}
+
+	if m.After == nil {
+		m.After = DefaultAfter
+	}
+
+	for _, u := range m.excludeURLs {
+		if r.URL.Path == u {
+			next(rw, r)
+			return
+		}
+	}
+
+	start := m.clock.Now()
+
+	// Try to get the real IP
+	remoteAddr := r.RemoteAddr
+	if realIP := r.Header.Get("X-Real-IP"); realIP != "" {
+		remoteAddr = realIP
+	}
+
+	entry := logrus.NewEntry(m.Logger)
+
+	if reqID := r.Header.Get("X-Request-Id"); reqID != "" {
+		entry = entry.WithField("request_id", reqID)
+	}
+
+	entry = m.Before(entry, r, remoteAddr)
+
+	if m.logStarting {
+		entry.Log(m.logLevel, "started handling request")
+	}
+
+	next(rw, r)
+
+	latency := m.clock.Since(start)
+	res := rw.(negroni.ResponseWriter)
+
+	if m.logCompleted {
+		m.After(entry, res, latency, m.Name).Log(m.logLevel, "completed handling request")
+	}
+}
+
+// BeforeFunc is the func type used to modify or replace the *logrus.Entry prior
+// to calling the next func in the middleware chain
+type BeforeFunc func(*logrus.Entry, *http.Request, string) *logrus.Entry
+
+// AfterFunc is the func type used to modify or replace the *logrus.Entry after
+// calling the next func in the middleware chain
+type AfterFunc func(*logrus.Entry, negroni.ResponseWriter, time.Duration, string) *logrus.Entry
+
+// DefaultBefore is the default func assigned to *Middleware.Before
+func DefaultBefore(entry *logrus.Entry, req *http.Request, remoteAddr string) *logrus.Entry {
+	return entry.WithFields(logrus.Fields{
+		"request": req.RequestURI,
+		"method":  req.Method,
+		"remote":  remoteAddr,
+	})
+}
+
+// DefaultAfter is the default func assigned to *Middleware.After
+func DefaultAfter(entry *logrus.Entry, res negroni.ResponseWriter, latency time.Duration, name string) *logrus.Entry {
+	return entry.WithFields(logrus.Fields{
+		"status":                                res.Status(),
+		"text_status":                           http.StatusText(res.Status()),
+		"took":                                  latency,
+		fmt.Sprintf("measure#%s.latency", name): latency.Nanoseconds(),
+	})
+}

--- a/internal/engine/goliac_reconciliator.go
+++ b/internal/engine/goliac_reconciliator.go
@@ -25,7 +25,7 @@ type UnmanagedResources struct {
  * GoliacReconciliator is here to sync the local state to the remote state
  */
 type GoliacReconciliator interface {
-	Reconciliate(ctx context.Context, local GoliacLocal, remote GoliacRemote, teamreponame string, dryrun bool, goliacAdminSlug string, reposToArchive map[string]*GithubRepoComparable) (*UnmanagedResources, error)
+	Reconciliate(ctx context.Context, local GoliacLocal, remote GoliacRemote, teamreponame string, dryrun bool, goliacAdminSlug string, reposToArchive map[string]*GithubRepoComparable, reposToRename map[string]*entity.Repository) (*UnmanagedResources, error)
 }
 
 type GoliacReconciliatorImpl struct {
@@ -42,7 +42,7 @@ func NewGoliacReconciliatorImpl(executor ReconciliatorExecutor, repoconfig *conf
 	}
 }
 
-func (r *GoliacReconciliatorImpl) Reconciliate(ctx context.Context, local GoliacLocal, remote GoliacRemote, teamsreponame string, dryrun bool, goliacAdminSlug string, reposToArchive map[string]*GithubRepoComparable) (*UnmanagedResources, error) {
+func (r *GoliacReconciliatorImpl) Reconciliate(ctx context.Context, local GoliacLocal, remote GoliacRemote, teamsreponame string, dryrun bool, goliacAdminSlug string, reposToArchive map[string]*GithubRepoComparable, reposToRename map[string]*entity.Repository) (*UnmanagedResources, error) {
 	rremote := NewMutableGoliacRemoteImpl(ctx, remote)
 	r.Begin(ctx, dryrun)
 	unmanaged := &UnmanagedResources{
@@ -66,7 +66,7 @@ func (r *GoliacReconciliatorImpl) Reconciliate(ctx context.Context, local Goliac
 		return nil, err
 	}
 
-	err = r.reconciliateRepositories(ctx, local, rremote, teamsreponame, dryrun, reposToArchive)
+	err = r.reconciliateRepositories(ctx, local, rremote, teamsreponame, dryrun, reposToArchive, reposToRename)
 	if err != nil {
 		r.Rollback(ctx, dryrun, err)
 		return nil, err
@@ -361,7 +361,7 @@ type GithubRepoComparable struct {
  * This function sync repositories and team's repositories permissions
  * It returns the list of deleted repos that must not be deleted but archived
  */
-func (r *GoliacReconciliatorImpl) reconciliateRepositories(ctx context.Context, local GoliacLocal, remote *MutableGoliacRemoteImpl, teamsreponame string, dryrun bool, toArchive map[string]*GithubRepoComparable) error {
+func (r *GoliacReconciliatorImpl) reconciliateRepositories(ctx context.Context, local GoliacLocal, remote *MutableGoliacRemoteImpl, teamsreponame string, dryrun bool, toArchive map[string]*GithubRepoComparable, reposToRename map[string]*entity.Repository) error {
 	ghRepos := remote.Repositories()
 	rRepos := make(map[string]*GithubRepoComparable)
 
@@ -411,6 +411,19 @@ func (r *GoliacReconciliatorImpl) reconciliateRepositories(ctx context.Context, 
 
 	localRepositories := make(map[string]*entity.Repository)
 	for reponame, repo := range local.Repositories() {
+
+		// we rename the repository before we start to reconciliate
+		if repo.RenameTo != "" {
+			renamedRepo := *repo
+			renamedRepo.Name = repo.RenameTo
+			renamedRepo.RenameTo = ""
+
+			r.RenameRepository(ctx, dryrun, remote, repo.Name, repo.RenameTo)
+
+			reposToRename[repo.DirectoryPath] = repo
+			repo = &renamedRepo
+		}
+
 		localRepositories[reponame] = repo
 	}
 
@@ -841,6 +854,15 @@ func (r *GoliacReconciliatorImpl) DeleteRepository(ctx context.Context, dryrun b
 		r.unmanaged.Repositories[reponame] = true
 	}
 }
+
+func (r *GoliacReconciliatorImpl) RenameRepository(ctx context.Context, dryrun bool, remote *MutableGoliacRemoteImpl, reponame string, newname string) {
+	logrus.WithFields(map[string]interface{}{"dryrun": dryrun, "command": "rename_repository"}).Infof("repositoryname: %s newname: %s", reponame, newname)
+	remote.RenameRepository(reponame, newname)
+	if r.executor != nil {
+		r.executor.RenameRepository(ctx, dryrun, reponame, newname)
+	}
+}
+
 func (r *GoliacReconciliatorImpl) UpdateRepositoryUpdateBoolProperty(ctx context.Context, dryrun bool, remote *MutableGoliacRemoteImpl, reponame string, propertyName string, propertyValue bool) {
 	logrus.WithFields(map[string]interface{}{"dryrun": dryrun, "command": "update_repository_update_bool_property"}).Infof("repositoryname: %s %s:%v", reponame, propertyName, propertyValue)
 	remote.UpdateRepositoryUpdateBoolProperty(reponame, propertyName, propertyValue)

--- a/internal/engine/local_test.go
+++ b/internal/engine/local_test.go
@@ -729,7 +729,7 @@ func TestGoliacLocalImpl(t *testing.T) {
 		}
 
 		// archive the repository 'repo1'
-		err = g.ArchiveRepos([]string{"repo1"}, "none", "master", "foobar")
+		err = g.UpdateRepos([]string{"repo1"}, map[string]*entity.Repository{}, "none", "master", "foobar")
 		assert.Nil(t, err)
 
 		// check the content of the 'archived/repo1.yaml' file

--- a/internal/engine/mutable_remote.go
+++ b/internal/engine/mutable_remote.go
@@ -204,6 +204,8 @@ func (m *MutableGoliacRemoteImpl) DeleteRepository(reponame string) {
 
 func (m *MutableGoliacRemoteImpl) RenameRepository(reponame string, newname string) {
 	r := m.repositories[reponame]
+
+	// it is not supposed to be nil
 	if r == nil {
 		return
 	}

--- a/internal/engine/mutable_remote.go
+++ b/internal/engine/mutable_remote.go
@@ -202,6 +202,26 @@ func (m *MutableGoliacRemoteImpl) DeleteRepository(reponame string) {
 	delete(m.repositories, reponame)
 }
 
+func (m *MutableGoliacRemoteImpl) RenameRepository(reponame string, newname string) {
+	r := m.repositories[reponame]
+	if r == nil {
+		return
+	}
+	delete(m.repositories, reponame)
+	r.Name = newname
+	m.repositories[newname] = r
+
+	for _, tr := range m.teamRepos {
+		for rname, r := range tr {
+			if rname == reponame {
+				delete(tr, rname)
+				r.Name = newname
+				tr[newname] = r
+			}
+		}
+	}
+}
+
 /*
 UpdateRepositoryUpdateBoolProperty is used for
 - private

--- a/internal/engine/reconciliator_executor.go
+++ b/internal/engine/reconciliator_executor.go
@@ -25,6 +25,7 @@ type ReconciliatorExecutor interface {
 	UpdateRepositoryRemoveExternalUser(ctx context.Context, dryrun bool, reponame string, githubid string)
 	UpdateRepositoryRemoveInternalUser(ctx context.Context, dryrun bool, reponame string, githubid string)
 	DeleteRepository(ctx context.Context, dryrun bool, reponame string)
+	RenameRepository(ctx context.Context, dryrun bool, reponame string, newname string)
 
 	Begin(dryrun bool)
 	Rollback(dryrun bool, err error)

--- a/internal/engine/remote.go
+++ b/internal/engine/remote.go
@@ -682,7 +682,7 @@ func (g *GoliacRemoteImpl) loadAppIds(ctx context.Context) (map[string]int, erro
 	logrus.Debug("loading appIds")
 	appIds := map[string]int{}
 	type Installation struct {
-		TotalClount   int `json:"total_count"`
+		TotalCount    int `json:"total_count"`
 		Installations []struct {
 			Id      int    `json:"id"`
 			AppId   int    `json:"app_id"`
@@ -703,7 +703,7 @@ func (g *GoliacRemoteImpl) loadAppIds(ctx context.Context) (map[string]int, erro
 	}
 
 	var installations Installation
-	json.Unmarshal(body, &installations)
+	err = json.Unmarshal(body, &installations)
 	if err != nil {
 		return nil, fmt.Errorf("not able to list github apps: %v", err)
 	}
@@ -712,9 +712,9 @@ func (g *GoliacRemoteImpl) loadAppIds(ctx context.Context) (map[string]int, erro
 		appIds[i.AppSlug] = i.AppId
 	}
 
-	if installations.TotalClount > 30 {
+	if installations.TotalCount > 30 {
 		// we need to paginate
-		for i := 2; i <= (installations.TotalClount/30)+1; i++ {
+		for i := 2; i <= (installations.TotalCount/30)+1; i++ {
 			body, err := g.client.CallRestAPI(ctx,
 				fmt.Sprintf("/orgs/%s/installations", config.Config.GithubAppOrganization),
 				fmt.Sprintf("page=%d&per_page=30", i),
@@ -726,7 +726,7 @@ func (g *GoliacRemoteImpl) loadAppIds(ctx context.Context) (map[string]int, erro
 			}
 
 			var installations Installation
-			json.Unmarshal(body, &installations)
+			err = json.Unmarshal(body, &installations)
 			if err != nil {
 				return nil, fmt.Errorf("not able to list github apps: %v", err)
 			}

--- a/internal/engine/remote.go
+++ b/internal/engine/remote.go
@@ -2170,6 +2170,29 @@ func (g *GoliacRemoteImpl) DeleteRepository(ctx context.Context, dryrun bool, re
 	}
 
 }
+func (g *GoliacRemoteImpl) RenameRepository(ctx context.Context, dryrun bool, reponame string, newname string) {
+	// update repository
+	// https://docs.github.com/fr/rest/repos/repos?apiVersion=2022-11-28#update-a-repository
+	if !dryrun {
+		body, err := g.client.CallRestAPI(
+			ctx,
+			fmt.Sprintf("/repos/%s/%s", config.Config.GithubAppOrganization, reponame),
+			"",
+			"PATCH",
+			map[string]interface{}{"name": newname},
+		)
+		if err != nil {
+			logrus.Errorf("failed to rename the repository %s (to %s): %v. %s", reponame, newname, err, string(body))
+		}
+	}
+
+	// update the repositories list
+	if r, ok := g.repositories[reponame]; ok {
+		delete(g.repositories, reponame)
+		r.Name = newname
+		g.repositories[reponame] = r
+	}
+}
 func (g *GoliacRemoteImpl) Begin(dryrun bool) {
 }
 func (g *GoliacRemoteImpl) Rollback(dryrun bool, err error) {

--- a/internal/engine/remote_test.go
+++ b/internal/engine/remote_test.go
@@ -404,6 +404,27 @@ func (m *MockGithubClient) CallRestAPI(ctx context.Context, endpoint, parameters
 		}
 		return []byte(fmt.Sprintf(`[{"name":"team_1","permission":"push","slug":"slug-%d"},{"name":"team_2","permission":"push","slug":"slug-2"}]`, repoId)), nil
 	}
+	if strings.HasSuffix(endpoint, "installations") {
+
+		type Installation struct {
+			TotalCount    int `json:"total_count"`
+			Installations []struct {
+				Id      int    `json:"id"`
+				AppId   int    `json:"app_id"`
+				Name    string `json:"name"`
+				AppSlug string `json:"app_slug"`
+			} `json:"installations"`
+		}
+
+		installation := Installation{
+			TotalCount: 0,
+		}
+		body, err := json.Marshal(&installation)
+		if err == nil {
+			return body, nil
+		}
+
+	}
 	return nil, nil
 }
 

--- a/internal/entity/repository.go
+++ b/internal/entity/repository.go
@@ -22,8 +22,10 @@ type Repository struct {
 		DeleteBranchOnMerge bool     `yaml:"delete_branch_on_merge,omitempty"`
 		AllowUpdateBranch   bool     `yaml:"allow_update_branch,omitempty"`
 	} `yaml:"spec,omitempty"`
-	Archived bool    `yaml:"archived,omitempty"` // implicit: will be set by Goliac
-	Owner    *string `yaml:"owner,omitempty"`    // implicit. team name owning the repo (if any)
+	Archived      bool    `yaml:"archived,omitempty"` // implicit: will be set by Goliac
+	Owner         *string `yaml:"-"`                  // implicit. team name owning the repo (if any)
+	RenameTo      string  `yaml:"renameTo,omitempty"`
+	DirectoryPath string  `yaml:"-"` // used to know where to rename the repository
 }
 
 /*
@@ -41,6 +43,7 @@ func NewRepository(fs billy.Filesystem, filename string) (*Repository, error) {
 	if err != nil {
 		return nil, err
 	}
+	repository.DirectoryPath = filepath.Dir(filename)
 
 	return repository, nil
 }

--- a/internal/github_batch_executor.go
+++ b/internal/github_batch_executor.go
@@ -204,6 +204,15 @@ func (g *GithubBatchExecutor) DeleteRepository(ctx context.Context, dryrun bool,
 	})
 }
 
+func (g *GithubBatchExecutor) RenameRepository(ctx context.Context, dryrun bool, reponame string, newname string) {
+	g.commands = append(g.commands, &GithubCommandRenameRepository{
+		client:   g.client,
+		dryrun:   dryrun,
+		reponame: reponame,
+		newname:  newname,
+	})
+}
+
 func (g *GithubBatchExecutor) AddRuleset(ctx context.Context, dryrun bool, ruleset *engine.GithubRuleSet) {
 	g.commands = append(g.commands, &GithubCommandAddRuletset{
 		client:  g.client,
@@ -290,6 +299,17 @@ type GithubCommandDeleteRepository struct {
 
 func (g *GithubCommandDeleteRepository) Apply(ctx context.Context) {
 	g.client.DeleteRepository(ctx, g.dryrun, g.reponame)
+}
+
+type GithubCommandRenameRepository struct {
+	client   engine.ReconciliatorExecutor
+	dryrun   bool
+	reponame string
+	newname  string
+}
+
+func (g *GithubCommandRenameRepository) Apply(ctx context.Context) {
+	g.client.RenameRepository(ctx, g.dryrun, g.reponame, g.newname)
 }
 
 type GithubCommandDeleteTeam struct {

--- a/internal/goliac_test.go
+++ b/internal/goliac_test.go
@@ -405,25 +405,25 @@ func (e *GoliacRemoteExecutorMock) TeamSlugByName(ctx context.Context) map[strin
 
 func (e *GoliacRemoteExecutorMock) Teams(ctx context.Context) map[string]*engine.GithubTeam {
 	return map[string]*engine.GithubTeam{
-		"team1": &engine.GithubTeam{
+		"team1": {
 			Slug:        "team1",
 			Name:        "team1",
 			Members:     e.teams1Members,
 			Maintainers: []string{},
 		},
-		"team2": &engine.GithubTeam{
+		"team2": {
 			Slug:        "team2",
 			Name:        "team2",
 			Members:     e.teams2Members,
 			Maintainers: []string{},
 		},
-		"team1-goliac-owners": &engine.GithubTeam{
+		"team1-goliac-owners": {
 			Slug:        "team1-goliac-owners",
 			Name:        "team1-goliac-owners",
 			Members:     e.teams1Members,
 			Maintainers: []string{},
 		},
-		"team2-goliac-owners": &engine.GithubTeam{
+		"team2-goliac-owners": {
 			Slug:        "team2-goliac-owners",
 			Name:        "team2-goliac-owners",
 			Members:     e.teams2Members,
@@ -433,7 +433,7 @@ func (e *GoliacRemoteExecutorMock) Teams(ctx context.Context) map[string]*engine
 }
 func (e *GoliacRemoteExecutorMock) Repositories(ctx context.Context) map[string]*engine.GithubRepository {
 	return map[string]*engine.GithubRepository{
-		"src": &engine.GithubRepository{
+		"src": {
 			Name:  "src", // this is the "teams" repository
 			Id:    0,
 			RefId: "MDEwOlJlcG9zaXRvcnkaMTMxNjExOQ==",
@@ -446,7 +446,7 @@ func (e *GoliacRemoteExecutorMock) Repositories(ctx context.Context) map[string]
 			},
 			ExternalUsers: map[string]string{},
 		},
-		"repo1": &engine.GithubRepository{
+		"repo1": {
 			Name:  "repo1",
 			Id:    1,
 			RefId: "MDEwOlJlcG9zaXRvcnkaMTMxNjExOQ==",
@@ -459,7 +459,7 @@ func (e *GoliacRemoteExecutorMock) Repositories(ctx context.Context) map[string]
 			},
 			ExternalUsers: map[string]string{},
 		},
-		"repo2": &engine.GithubRepository{
+		"repo2": {
 			Name:  "repo2",
 			Id:    2,
 			RefId: "MDEwOlJlcG9zaXRvcnkaNTcwNDA4Ng==",

--- a/internal/goliac_test.go
+++ b/internal/goliac_test.go
@@ -148,43 +148,11 @@ spec:
 // - missing user4 in the teams repo
 // - using the `fromgithubsaml` user sync plugin
 func repoFixture2(fs billy.Filesystem) {
-	fs.MkdirAll("teams", 0755)
-	fs.MkdirAll("archived", 0755)
+	repoFixture1(fs)
 
-	// create users
-	fs.MkdirAll("users/external", 0755)
-	fs.MkdirAll("users/org", 0755)
-	fs.MkdirAll("users/protected", 0755)
-	utils.WriteFile(fs, "users/org/user1.yaml", []byte(`apiVersion: v1
-kind: User
-name: user1
-spec:
-  githubID: github1
-`), 0644)
-	utils.WriteFile(fs, "users/org/user2.yaml", []byte(`apiVersion: v1
-kind: User
-name: user2
-spec:
-  githubID: github2
-`), 0644)
-	utils.WriteFile(fs, "users/org/user3.yaml", []byte(`apiVersion: v1
-kind: User
-name: user3
-spec:
-  githubID: github3
-`), 0644)
+	fs.Remove("users/org/user4.yaml")
 
-	// create teams
-	fs.MkdirAll("teams/team1", 0755)
-	utils.WriteFile(fs, "teams/team1/team.yaml", []byte(`apiVersion: v1
-kind: Team
-name: team1
-spec:
-  owners:
-    - user1
-    - user2
-`), 0644)
-	fs.MkdirAll("teams/team2", 0755)
+	// without user4 owner
 	utils.WriteFile(fs, "teams/team2/team.yaml", []byte(`apiVersion: v1
 kind: Team
 name: team2
@@ -193,61 +161,18 @@ spec:
     - user3
 `), 0644)
 
-	// create repositories
-	utils.WriteFile(fs, "teams/team1/repo1.yaml", []byte(`apiVersion: v1
-kind: Repository
-name: repo1
-`), 0644)
+}
+
+// create a working simple teams repository
+func repoFixtureRename(fs billy.Filesystem) {
+	repoFixture1(fs)
+
 	utils.WriteFile(fs, "teams/team2/repo2.yaml", []byte(`apiVersion: v1
 kind: Repository
 name: repo2
+renameTo: repo3
 `), 0644)
 
-	// create goliac.yaml
-	utils.WriteFile(fs, "goliac.yaml", []byte(`admin_team: admin
-
-rulesets:
-  - pattern: .*
-    ruleset: default
-
-max_changesets: 50
-archive_on_delete: true
-
-destructive_operations:
-  repositories: false
-  teams: false
-  users: false
-  rulesets: false
-
-usersync:
-  plugin: fromgithubsaml
-`), 0644)
-	// rulesets
-	fs.MkdirAll("rulesets", 0755)
-	utils.WriteFile(fs, "rulesets/default.yaml", []byte(`apiVersion: v1
-kind: Ruleset
-name: default
-spec:
-  enforcement: active
-  bypassapps:
-    - appname: goliac-project-app
-      mode: always
-  on:
-    include: 
-      - "~DEFAULT_BRANCH"
-
-  rules:
-    - ruletype: pull_request
-      parameters:
-        requiredApprovingReviewCount: 1
-`), 0644)
-
-	// create .github/CODEOWNERS
-	utils.WriteFile(fs, ".github/CODEOWNERS", []byte(`# DO NOT MODIFY THIS FILE MANUALLY
-* @goliac-project/admin
-/teams/team1/* @goliac-project/team1-goliac-owners @goliac-project/admin
-/teams/team2/* @goliac-project/team2-goliac-owners @goliac-project/admin
-`), 0644)
 }
 
 func createTeamRepo(src billy.Filesystem, fixtureFunc FixtureFunc) (*git.Repository, error) {
@@ -698,6 +623,10 @@ func (e *GoliacRemoteExecutorMock) DeleteRepository(ctx context.Context, dryrun 
 	fmt.Println("*** DeleteRepository", reponame)
 	e.nbChanges++
 }
+func (e *GoliacRemoteExecutorMock) RenameRepository(ctx context.Context, dryrun bool, reponame string, newname string) {
+	fmt.Println("*** RenameRepository", reponame, newname)
+	e.nbChanges++
+}
 
 func (e *GoliacRemoteExecutorMock) Begin(dryrun bool) {
 }
@@ -749,6 +678,44 @@ func TestGoliacApply(t *testing.T) {
 		assert.Equal(t, len(warns), 0)
 		assert.NotNil(t, unmanaged)
 		assert.Equal(t, 0, remote.nbChanges)
+	})
+
+	t.Run("happy path: rename a repo", func(t *testing.T) {
+
+		fs := memfs.New()
+		fs.MkdirAll("src", 0755)        // create a fake bare repository
+		fs.MkdirAll("teams", 0755)      // create a fake cloned repository
+		fs.MkdirAll(os.TempDir(), 0755) // need a tmp folder
+		srcsFs, _ := fs.Chroot("src")
+		clonedFs, _ := fs.Chroot("teams")
+		_, _, err := helperCreateAndClone(fs, srcsFs, clonedFs, repoFixtureRename)
+		assert.Nil(t, err)
+
+		local := engine.NewGoliacLocalImpl()
+
+		errs, warns := local.LoadAndValidateLocal(clonedFs)
+		assert.Equal(t, len(errs), 0)
+		assert.Equal(t, len(warns), 0)
+
+		githubClient := NewGitHubClientMock()
+		remote := NewGoliacRemoteExecutorMock().(*GoliacRemoteExecutorMock)
+
+		usersync.InitPlugins(githubClient)
+
+		goliac := GoliacImpl{
+			local:              local,
+			remote:             remote,
+			remoteGithubClient: githubClient,
+			localGithubClient:  githubClient,
+			repoconfig:         &config.RepositoryConfig{},
+		}
+
+		err, errs, warns, unmanaged := goliac.Apply(context.Background(), fs, false, "inmemory:///src", "master")
+		assert.Nil(t, err)
+		assert.Equal(t, len(errs), 0)
+		assert.Equal(t, len(warns), 0)
+		assert.NotNil(t, unmanaged)
+		assert.Equal(t, 1, remote.nbChanges) // 1 team renamed
 	})
 
 	t.Run("happy path: user4 to sync", func(t *testing.T) {


### PR DESCRIPTION
allow to rename a repository by adding a `renameTo`, like

```
kind: Repository
name: repo2
spec:
  ...
renameTo: repo3
```