### PR TITLE
V1 5 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Goliac v1.5.0
 
+- bugfix with Custom Properties, when the value is ''
+
+## Goliac v1.5.0
+
 - introducing repository Custom Properties
 
 ## Goliac v1.4.2

--- a/internal/engine/goliac_reconciliator.go
+++ b/internal/engine/goliac_reconciliator.go
@@ -478,7 +478,11 @@ func (r *GoliacReconciliatorImpl) reconciliateRepositories(
 							}
 						}
 						if found {
-							localCustomProperties[propName] = normalizePropertyValue(localValue)
+							normalizedValue := normalizePropertyValue(localValue)
+							// bug (or feature?) an empty string is not saved in Github
+							if normalizedValue != "" {
+								localCustomProperties[propName] = normalizedValue
+							}
 						} else {
 							logsCollector.AddWarn(fmt.Errorf("custom property %s is defined in the repository %s but not in the organization custom properties", propName, reponame))
 						}

--- a/internal/engine/local.go
+++ b/internal/engine/local.go
@@ -971,7 +971,7 @@ func (g *GoliacLocalImpl) LoadAndValidateLocal(fs billy.Filesystem, LogCollectio
 	g.teams = teams
 
 	// Parse all repositories in the <orgDirectory>/teams/<teamname> directories
-	repos := entity.ReadRepositories(fs, "archived", "teams", g.teams, g.externalUsers, LogCollection)
+	repos := entity.ReadRepositories(fs, "archived", "teams", g.teams, g.externalUsers, g.repoconfig.OrgCustomProperties, LogCollection)
 	g.repositories = repos
 
 	rulesets := entity.ReadRuleSetDirectory(fs, "rulesets", LogCollection)

--- a/internal/entity/repository_test.go
+++ b/internal/entity/repository_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/goliac-project/goliac/internal/config"
 	"github.com/goliac-project/goliac/internal/observability"
 	"github.com/goliac-project/goliac/internal/utils"
 	"github.com/stretchr/testify/assert"
@@ -70,7 +71,7 @@ name: repo1
 		assert.False(t, logsCollector.HasWarns())
 		assert.NotNil(t, teams)
 
-		repos := ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, logsCollector)
+		repos := ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, []*config.GithubCustomProperty{}, logsCollector)
 		assert.False(t, logsCollector.HasErrors())
 		assert.False(t, logsCollector.HasWarns())
 		assert.NotNil(t, repos)
@@ -98,7 +99,7 @@ name: repo2
 		assert.False(t, logsCollector.HasWarns())
 		assert.NotNil(t, teams)
 
-		ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, logsCollector)
+		ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, []*config.GithubCustomProperty{}, logsCollector)
 		assert.True(t, logsCollector.HasErrors())
 		assert.False(t, logsCollector.HasWarns())
 	})
@@ -128,7 +129,7 @@ spec:
 		assert.False(t, logsCollector.HasWarns())
 		assert.NotNil(t, teams)
 
-		ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, logsCollector)
+		ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, []*config.GithubCustomProperty{}, logsCollector)
 		assert.True(t, logsCollector.HasErrors())
 		assert.False(t, logsCollector.HasWarns())
 	})
@@ -158,7 +159,7 @@ spec:
 		assert.False(t, logsCollector.HasWarns())
 		assert.NotNil(t, teams)
 
-		ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, logsCollector)
+		ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, []*config.GithubCustomProperty{}, logsCollector)
 		assert.True(t, logsCollector.HasErrors())
 		assert.False(t, logsCollector.HasWarns())
 	})
@@ -187,7 +188,7 @@ spec:
 		assert.False(t, logsCollector.HasWarns())
 		assert.NotNil(t, teams)
 
-		repos := ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, logsCollector)
+		repos := ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, []*config.GithubCustomProperty{}, logsCollector)
 		assert.False(t, logsCollector.HasErrors())
 		assert.False(t, logsCollector.HasWarns())
 		assert.NotNil(t, repos)
@@ -216,7 +217,7 @@ name: repo1
 		assert.False(t, logsCollector.HasWarns())
 		assert.NotNil(t, teams)
 
-		repos := ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, logsCollector)
+		repos := ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, []*config.GithubCustomProperty{}, logsCollector)
 		assert.False(t, logsCollector.HasErrors())
 		assert.False(t, logsCollector.HasWarns())
 		assert.NotNil(t, repos)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Validates repository custom properties against org config, normalizes values, and skips empty-string properties when reconciling; wires org properties through loaders and updates changelog.
> 
> - **Engine**:
>   - Reconciliation: normalize custom property values and skip setting properties with empty-string values when updating repos.
>   - Local loading: pass `repoconfig.OrgCustomProperties` into `ReadRepositories`.
> - **Entity/Repository**:
>   - `NewRepository`: normalize `spec.custom_properties` (e.g., ints to strings).
>   - `ReadRepositories`/`Validate`: accept org custom properties and ensure repo properties exist in org definitions.
> - **Tests**:
>   - Update repository tests to pass org custom properties to `ReadRepositories`.
> - **Changelog**:
>   - Add note about custom properties bugfix when value is empty string and introduce repository custom properties.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18bd746a082bbccf227b15d862bf406c26a12290. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->