### PR TITLE
V1 5 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## Goliac v1.5.0
+## Goliac v1.5.2
+
+- custom properties scan can be disabled
+
+## Goliac v1.5.1
 
 - bugfix with Custom Properties, when the value is ''
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Goliac v1.5.2
 
 - custom properties scan can be disabled
+- fix branch protection bugs: when requiredStatusCheckContexts is not defined and ignore dismissesStaleReviews/requiresCodeOwnerReviews/requireLastPushApproval when requiresApprovingReviews is false
 
 ## Goliac v1.5.1
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -278,6 +278,7 @@ You can run the goliac server as a service or a docker container. It needs sever
 | GOLIAC_WORKFLOW_JIRA_EMAIL   |               | PR Breaking glass workflow - Jira plugin: email |
 | GOLIAC_WORKFLOW_JIRA_API_TOKEN |             | PR Breaking glass workflow - Jira plugin: token |
 | GOLIAC_MANAGE_GITHUB_ACTIONS_VARIABLES | true | if Goliac manage repositories environments, variables. For secrets it only scans them for display purposes |
+| GOLIAC_MANAGE_ORG_CUSTOM_PROPERTIES | true | if Goliac manage custom properties |
 
 then you just need to start it with
 

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -26,6 +26,8 @@ var Config = struct {
 	ManageGithubActionsVariables bool `env:"GOLIAC_MANAGE_GITHUB_ACTIONS_VARIABLES" envDefault:"true"`
 	// ManageGithubAutolinks - to manage Github repositoryAutolinks
 	ManageGithubAutolinks bool `env:"GOLIAC_MANAGE_GITHUB_AUTOLINKS" envDefault:"true"`
+	// ManageOrgCustomProperties - to manage Github organization custom properties
+	ManageOrgCustomProperties bool `env:"GOLIAC_MANAGE_ORG_CUSTOM_PROPERTIES" envDefault:"true"`
 
 	ServerApplyInterval int64  `env:"GOLIAC_SERVER_APPLY_INTERVAL" envDefault:"600"`
 	ServerGitRepository string `env:"GOLIAC_SERVER_GIT_REPOSITORY" envDefault:""`

--- a/internal/engine/goliac_reconciliator.go
+++ b/internal/engine/goliac_reconciliator.go
@@ -797,14 +797,20 @@ func compareBranchProtections(bpname string, lbp *GithubBranchProtection, rbp *G
 			return false
 		}
 	}
-	if lbp.DismissesStaleReviews != rbp.DismissesStaleReviews {
-		return false
+	if lbp.RequiresApprovingReviews {
+		if lbp.DismissesStaleReviews != rbp.DismissesStaleReviews {
+			return false
+		}
 	}
-	if lbp.RequiresCodeOwnerReviews != rbp.RequiresCodeOwnerReviews {
-		return false
+	if lbp.RequiresApprovingReviews {
+		if lbp.RequiresCodeOwnerReviews != rbp.RequiresCodeOwnerReviews {
+			return false
+		}
 	}
-	if lbp.RequireLastPushApproval != rbp.RequireLastPushApproval {
-		return false
+	if lbp.RequiresApprovingReviews {
+		if lbp.RequireLastPushApproval != rbp.RequireLastPushApproval {
+			return false
+		}
 	}
 	if lbp.RequiresStatusChecks != rbp.RequiresStatusChecks {
 		return false

--- a/internal/engine/remote.go
+++ b/internal/engine/remote.go
@@ -170,6 +170,7 @@ type GoliacRemoteImpl struct {
 	configGithubOrg           string
 	manageGithubVariables     bool
 	manageGithubAutolinks     bool
+	manageOrgCustomProperties bool
 }
 
 type GHESInfo struct {
@@ -325,6 +326,7 @@ func NewGoliacRemoteImpl(client github.GitHubClient,
 	configGithubOrg string,
 	manageGithubVariables bool,
 	manageGithubAutolinks bool,
+	manageOrgCustomProperties bool,
 ) *GoliacRemoteImpl {
 	ctx := context.Background()
 	return &GoliacRemoteImpl{
@@ -350,6 +352,7 @@ func NewGoliacRemoteImpl(client github.GitHubClient,
 		configGithubOrg:           configGithubOrg,
 		manageGithubVariables:     manageGithubVariables,
 		manageGithubAutolinks:     manageGithubAutolinks,
+		manageOrgCustomProperties: manageOrgCustomProperties,
 	}
 }
 
@@ -1060,14 +1063,16 @@ func (g *GoliacRemoteImpl) loadRepositories(ctx context.Context, githubToken *st
 		}
 	}
 
-	// Load custom properties for all repositories
-	customPropsPerRepo, err := g.loadCustomPropertiesConcurrently(ctx, config.Config.GithubConcurrentThreads, repositories)
-	if err != nil {
-		logrus.Warnf("error loading custom properties: %v", err)
-	} else {
-		for reponame, customProps := range customPropsPerRepo {
-			if repo, ok := repositories[reponame]; ok {
-				repo.CustomProperties = customProps
+	if g.manageOrgCustomProperties {
+		// Load custom properties for all repositories
+		customPropsPerRepo, err := g.loadCustomPropertiesConcurrently(ctx, config.Config.GithubConcurrentThreads, repositories)
+		if err != nil {
+			logrus.Warnf("error loading custom properties: %v", err)
+		} else {
+			for reponame, customProps := range customPropsPerRepo {
+				if repo, ok := repositories[reponame]; ok {
+					repo.CustomProperties = customProps
+				}
 			}
 		}
 	}

--- a/internal/engine/remote.go
+++ b/internal/engine/remote.go
@@ -3073,6 +3073,10 @@ func (g *GoliacRemoteImpl) UpdateRepositoryBranchProtection(ctx context.Context,
 	}
 
 	if !dryrun {
+		statusCheckContexts := branchprotection.RequiredStatusCheckContexts
+		if statusCheckContexts == nil {
+			statusCheckContexts = []string{}
+		}
 		body, err := g.client.QueryGraphQLAPI(
 			ctx,
 			updateBranchProtectionRule,
@@ -3086,7 +3090,7 @@ func (g *GoliacRemoteImpl) UpdateRepositoryBranchProtection(ctx context.Context,
 				"requireLastPushApproval":        branchprotection.RequireLastPushApproval,
 				"requiresStatusChecks":           branchprotection.RequiresStatusChecks,
 				"requiresStrictStatusChecks":     branchprotection.RequiresStrictStatusChecks,
-				"requiredStatusCheckContexts":    branchprotection.RequiredStatusCheckContexts,
+				"requiredStatusCheckContexts":    statusCheckContexts,
 				"requiresConversationResolution": branchprotection.RequiresConversationResolution,
 				"requiresCommitSignatures":       branchprotection.RequiresCommitSignatures,
 				"requiresLinearHistory":          branchprotection.RequiresLinearHistory,

--- a/internal/engine/remote_actions_test.go
+++ b/internal/engine/remote_actions_test.go
@@ -91,7 +91,7 @@ func TestLoadEnvironmentsPerRepository(t *testing.T) {
 			}`,
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		repo := &GithubRepository{
 			Name: "test-repo",
 			Id:   123,
@@ -128,7 +128,7 @@ func TestLoadEnvironmentsPerRepository(t *testing.T) {
 			errorMessage: "API error",
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		repo := &GithubRepository{
 			Name: "test-repo",
 			Id:   123,
@@ -150,7 +150,7 @@ func TestLoadEnvironmentsPerRepository(t *testing.T) {
 			responseBody: `invalid json`,
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		repo := &GithubRepository{
 			Name: "test-repo",
 			Id:   123,
@@ -175,7 +175,7 @@ func TestLoadEnvironmentsPerRepository(t *testing.T) {
 			}`,
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		repo := &GithubRepository{
 			Name: "test-repo",
 			Id:   123,
@@ -270,7 +270,7 @@ func TestLoadVariablesPerRepository(t *testing.T) {
 			}`,
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		repo := &GithubRepository{
 			Name: "test-repo",
 			Id:   123,
@@ -311,7 +311,7 @@ func TestLoadVariablesPerRepository(t *testing.T) {
 			errorMessage: "API error",
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		repo := &GithubRepository{
 			Name: "test-repo",
 			Id:   123,
@@ -333,7 +333,7 @@ func TestLoadVariablesPerRepository(t *testing.T) {
 			accessTokenErr: fmt.Errorf("failed to get access token"),
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		repo := &GithubRepository{
 			Name: "test-repo",
 			Id:   123,
@@ -355,7 +355,7 @@ func TestLoadVariablesPerRepository(t *testing.T) {
 			responseBody: `invalid json`,
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		repo := &GithubRepository{
 			Name: "test-repo",
 			Id:   123,
@@ -380,7 +380,7 @@ func TestLoadVariablesPerRepository(t *testing.T) {
 			}`,
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		repo := &GithubRepository{
 			Name: "test-repo",
 			Id:   123,

--- a/internal/engine/remote_repository_branchprotection_test.go
+++ b/internal/engine/remote_repository_branchprotection_test.go
@@ -65,7 +65,7 @@ func TestAddRepositoryBranchProtection(t *testing.T) {
 	t.Run("happy path: add branch protection", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &AddBranchProtectionMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository to the remote impl
 		repo := &GithubRepository{
@@ -134,7 +134,7 @@ func TestAddRepositoryBranchProtection(t *testing.T) {
 	t.Run("error path: repository not found", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &AddBranchProtectionMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Setup test data
 		branchProtection := &GithubBranchProtection{
@@ -161,7 +161,7 @@ func TestAddRepositoryBranchProtection(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "failed to create branch protection",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository to the remote impl
 		repo := &GithubRepository{
@@ -196,7 +196,7 @@ func TestAddRepositoryBranchProtection(t *testing.T) {
 	t.Run("happy path: dry run", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &AddBranchProtectionMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository to the remote impl
 		repo := &GithubRepository{
@@ -242,7 +242,7 @@ func TestAddRepositoryBranchProtection(t *testing.T) {
 				]
 			}`,
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository to the remote impl
 		repo := &GithubRepository{
@@ -329,7 +329,7 @@ func TestDeleteRepositoryBranchProtection(t *testing.T) {
 	t.Run("happy path: delete branch protection", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &DeleteBranchProtectionMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository with branch protection to the remote impl
 		branchProtection := &GithubBranchProtection{
@@ -371,7 +371,7 @@ func TestDeleteRepositoryBranchProtection(t *testing.T) {
 	t.Run("error path: repository not found", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &DeleteBranchProtectionMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Setup test data
 		branchProtection := &GithubBranchProtection{
@@ -399,7 +399,7 @@ func TestDeleteRepositoryBranchProtection(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "failed to delete branch protection",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository with branch protection to the remote impl
 		branchProtection := &GithubBranchProtection{
@@ -435,7 +435,7 @@ func TestDeleteRepositoryBranchProtection(t *testing.T) {
 	t.Run("happy path: dry run", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &DeleteBranchProtectionMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository with branch protection to the remote impl
 		branchProtection := &GithubBranchProtection{
@@ -482,7 +482,7 @@ func TestDeleteRepositoryBranchProtection(t *testing.T) {
 				]
 			}`,
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository with branch protection to the remote impl
 		branchProtection := &GithubBranchProtection{
@@ -518,7 +518,7 @@ func TestDeleteRepositoryBranchProtection(t *testing.T) {
 	t.Run("happy path: delete non-existent branch protection", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &DeleteBranchProtectionMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository without branch protection to the remote impl
 		repo := &GithubRepository{
@@ -608,7 +608,7 @@ func TestUpdateRepositoryBranchProtection(t *testing.T) {
 	t.Run("happy path: update branch protection", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateBranchProtectionMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository with existing branch protection to the remote impl
 		existingBranchProtection := &GithubBranchProtection{
@@ -697,7 +697,7 @@ func TestUpdateRepositoryBranchProtection(t *testing.T) {
 	t.Run("error path: repository not found", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateBranchProtectionMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Setup test data
 		branchProtection := &GithubBranchProtection{
@@ -725,7 +725,7 @@ func TestUpdateRepositoryBranchProtection(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "failed to update branch protection",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository with branch protection to the remote impl
 		originalBranchProtection := &GithubBranchProtection{
@@ -768,7 +768,7 @@ func TestUpdateRepositoryBranchProtection(t *testing.T) {
 	t.Run("happy path: dry run", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateBranchProtectionMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository with branch protection to the remote impl
 		originalBranchProtection := &GithubBranchProtection{
@@ -822,7 +822,7 @@ func TestUpdateRepositoryBranchProtection(t *testing.T) {
 				]
 			}`,
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository with branch protection to the remote impl
 		originalBranchProtection := &GithubBranchProtection{

--- a/internal/engine/remote_repository_environment_test.go
+++ b/internal/engine/remote_repository_environment_test.go
@@ -89,7 +89,7 @@ func TestLoadEnvironmentVariablesForEnvironmentRepository(t *testing.T) {
 			}`,
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 
 		// Call loadEnvironmentVariablesForEnvironmentRepository
@@ -115,7 +115,7 @@ func TestLoadEnvironmentVariablesForEnvironmentRepository(t *testing.T) {
 			errorMessage: "API error",
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 
 		// Call loadEnvironmentVariablesForEnvironmentRepository
@@ -132,7 +132,7 @@ func TestLoadEnvironmentVariablesForEnvironmentRepository(t *testing.T) {
 			responseBody: `invalid json`,
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 
 		// Call loadEnvironmentVariablesForEnvironmentRepository
@@ -152,7 +152,7 @@ func TestLoadEnvironmentVariablesForEnvironmentRepository(t *testing.T) {
 			}`,
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 
 		// Call loadEnvironmentVariablesForEnvironmentRepository
@@ -180,7 +180,7 @@ func TestLoadEnvironmentVariablesForEnvironmentRepository(t *testing.T) {
 			}`,
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 
 		// Call loadEnvironmentVariablesForEnvironmentRepository
@@ -222,7 +222,7 @@ func TestLoadEnvironmentVariablesForEnvironmentRepository(t *testing.T) {
 			}`,
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 
 		// Create a repository with an environment
@@ -279,7 +279,7 @@ func TestAddRepositoryEnvironment(t *testing.T) {
 		// Setup mock client
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -320,7 +320,7 @@ func TestAddRepositoryEnvironment(t *testing.T) {
 	t.Run("error path: repository not found", func(t *testing.T) {
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -338,7 +338,7 @@ func TestAddRepositoryEnvironment(t *testing.T) {
 	t.Run("error path: environment already exists", func(t *testing.T) {
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -373,7 +373,7 @@ func TestAddRepositoryEnvironment(t *testing.T) {
 	t.Run("happy path: dry run mode", func(t *testing.T) {
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -413,7 +413,7 @@ func TestAddRepositoryEnvironment(t *testing.T) {
 			errorMessage: "API error",
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -455,7 +455,7 @@ func TestDeleteRepositoryEnvironment(t *testing.T) {
 		// Setup mock client
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -498,7 +498,7 @@ func TestDeleteRepositoryEnvironment(t *testing.T) {
 	t.Run("error path: repository not found", func(t *testing.T) {
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -516,7 +516,7 @@ func TestDeleteRepositoryEnvironment(t *testing.T) {
 	t.Run("error path: environment not found", func(t *testing.T) {
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -546,7 +546,7 @@ func TestDeleteRepositoryEnvironment(t *testing.T) {
 	t.Run("happy path: dry run mode", func(t *testing.T) {
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -588,7 +588,7 @@ func TestDeleteRepositoryEnvironment(t *testing.T) {
 			errorMessage: "API error",
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -636,7 +636,7 @@ func TestAddRepositoryEnvironmentVariable(t *testing.T) {
 		// Setup mock client
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -684,7 +684,7 @@ func TestAddRepositoryEnvironmentVariable(t *testing.T) {
 	t.Run("error path: repository not found", func(t *testing.T) {
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -702,7 +702,7 @@ func TestAddRepositoryEnvironmentVariable(t *testing.T) {
 	t.Run("error path: environment not found", func(t *testing.T) {
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -732,7 +732,7 @@ func TestAddRepositoryEnvironmentVariable(t *testing.T) {
 	t.Run("error path: variable already exists", func(t *testing.T) {
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -769,7 +769,7 @@ func TestAddRepositoryEnvironmentVariable(t *testing.T) {
 	t.Run("happy path: dry run mode", func(t *testing.T) {
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -813,7 +813,7 @@ func TestAddRepositoryEnvironmentVariable(t *testing.T) {
 			errorMessage: "API error",
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -865,7 +865,7 @@ func TestUpdateRepositoryVariable(t *testing.T) {
 		// Setup mock client
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -908,7 +908,7 @@ func TestUpdateRepositoryVariable(t *testing.T) {
 	t.Run("error path: repository not found", func(t *testing.T) {
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -926,7 +926,7 @@ func TestUpdateRepositoryVariable(t *testing.T) {
 	t.Run("error path: variable not found", func(t *testing.T) {
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -956,7 +956,7 @@ func TestUpdateRepositoryVariable(t *testing.T) {
 	t.Run("happy path: dry run mode", func(t *testing.T) {
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -995,7 +995,7 @@ func TestUpdateRepositoryVariable(t *testing.T) {
 			errorMessage: "API error",
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -1042,7 +1042,7 @@ func TestDeleteRepositoryVariable(t *testing.T) {
 		// Setup mock client
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -1082,7 +1082,7 @@ func TestDeleteRepositoryVariable(t *testing.T) {
 	t.Run("error path: repository not found", func(t *testing.T) {
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -1100,7 +1100,7 @@ func TestDeleteRepositoryVariable(t *testing.T) {
 	t.Run("error path: variable not found", func(t *testing.T) {
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -1130,7 +1130,7 @@ func TestDeleteRepositoryVariable(t *testing.T) {
 	t.Run("happy path: dry run mode", func(t *testing.T) {
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -1169,7 +1169,7 @@ func TestDeleteRepositoryVariable(t *testing.T) {
 			errorMessage: "API error",
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -1213,7 +1213,7 @@ func TestUpdateRepositoryEnvironmentVariable(t *testing.T) {
 		// Setup mock client
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -1263,7 +1263,7 @@ func TestUpdateRepositoryEnvironmentVariable(t *testing.T) {
 	t.Run("error path: repository not found", func(t *testing.T) {
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -1281,7 +1281,7 @@ func TestUpdateRepositoryEnvironmentVariable(t *testing.T) {
 	t.Run("error path: environment not found", func(t *testing.T) {
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -1311,7 +1311,7 @@ func TestUpdateRepositoryEnvironmentVariable(t *testing.T) {
 	t.Run("error path: variable not found", func(t *testing.T) {
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -1346,7 +1346,7 @@ func TestUpdateRepositoryEnvironmentVariable(t *testing.T) {
 	t.Run("happy path: dry run mode", func(t *testing.T) {
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -1392,7 +1392,7 @@ func TestUpdateRepositoryEnvironmentVariable(t *testing.T) {
 			errorMessage: "API error",
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -1446,7 +1446,7 @@ func TestDeleteRepositoryEnvironmentVariable(t *testing.T) {
 		// Setup mock client
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -1493,7 +1493,7 @@ func TestDeleteRepositoryEnvironmentVariable(t *testing.T) {
 	t.Run("error path: repository not found", func(t *testing.T) {
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -1511,7 +1511,7 @@ func TestDeleteRepositoryEnvironmentVariable(t *testing.T) {
 	t.Run("error path: environment not found", func(t *testing.T) {
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -1541,7 +1541,7 @@ func TestDeleteRepositoryEnvironmentVariable(t *testing.T) {
 	t.Run("error path: variable not found", func(t *testing.T) {
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -1576,7 +1576,7 @@ func TestDeleteRepositoryEnvironmentVariable(t *testing.T) {
 	t.Run("happy path: dry run mode", func(t *testing.T) {
 		mockClient := &LoadEnvironmentVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -1622,7 +1622,7 @@ func TestDeleteRepositoryEnvironmentVariable(t *testing.T) {
 			errorMessage: "API error",
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 

--- a/internal/engine/remote_repository_test.go
+++ b/internal/engine/remote_repository_test.go
@@ -71,7 +71,7 @@ func TestCreateRepository(t *testing.T) {
 			responseName:   "forked-repo",
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		// initiate the cache
 		remoteImpl.Load(ctx, false)
@@ -136,7 +136,7 @@ func TestCreateRepository(t *testing.T) {
 			responseName:   "forked-repo",
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		// initiate the cache
 		remoteImpl.Load(ctx, false)
@@ -199,7 +199,7 @@ func TestCreateRepository(t *testing.T) {
 			errorMessage: "invalid fork format",
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		// initiate the cache
 		remoteImpl.Load(ctx, false)
@@ -233,7 +233,7 @@ func TestCreateRepository(t *testing.T) {
 			errorMessage: "repository not found",
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		// initiate the cache
 		remoteImpl.Load(ctx, false)
@@ -272,7 +272,7 @@ func TestCreateRepository(t *testing.T) {
 			responseName:   "new-repo",
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		// initiate the cache
 		remoteImpl.Load(ctx, false)
@@ -339,7 +339,7 @@ func TestCreateRepository(t *testing.T) {
 		// Setup mock client
 		mockClient := &CreateRepositoryMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		// initiate the cache
 		remoteImpl.Load(ctx, false)
@@ -421,7 +421,7 @@ func TestDeleteRepository(t *testing.T) {
 		// Setup mock client
 		mockClient := &DeleteRepositoryMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -465,7 +465,7 @@ func TestDeleteRepository(t *testing.T) {
 			errorMessage: "repository not found",
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -491,7 +491,7 @@ func TestDeleteRepository(t *testing.T) {
 		// Setup mock client
 		mockClient := &DeleteRepositoryMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		remoteImpl.Load(ctx, false)
 		mockClient.lastEndpoint = ""
@@ -531,7 +531,7 @@ func TestDeleteRepository(t *testing.T) {
 		// Setup mock client
 		mockClient := &DeleteRepositoryMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -644,7 +644,7 @@ func TestRenameRepository(t *testing.T) {
 		// Setup mock client
 		mockClient := &RenameRepositoryMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		remoteImpl.Load(ctx, false)
 		logsCollector := observability.NewLogCollection()
@@ -725,7 +725,7 @@ func TestRenameRepository(t *testing.T) {
 			errorMessage: "repository not found",
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
 
@@ -752,7 +752,7 @@ func TestRenameRepository(t *testing.T) {
 		// Setup mock client
 		mockClient := &RenameRepositoryMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		remoteImpl.Load(ctx, false)
 		mockClient.lastEndpoint = ""
@@ -818,7 +818,7 @@ func TestRenameRepository(t *testing.T) {
 			errorMessage: "repository with this name already exists",
 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 		ctx := context.TODO()
 		remoteImpl.Load(ctx, false)
 		mockClient.lastEndpoint = ""

--- a/internal/engine/remote_repositoryruleset_test.go
+++ b/internal/engine/remote_repositoryruleset_test.go
@@ -59,7 +59,7 @@ func TestCreateRepositoryRuleset(t *testing.T) {
 	t.Run("happy path: create repository ruleset", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &CreateRepositoryRulesetMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository to the remote impl
 		repo := &GithubRepository{
@@ -188,7 +188,7 @@ func TestCreateRepositoryRuleset(t *testing.T) {
 	t.Run("error path: repository not found", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &CreateRepositoryRulesetMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Setup test data
 		ruleset := &GithubRuleSet{
@@ -221,7 +221,7 @@ func TestCreateRepositoryRuleset(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "failed to create ruleset",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository to the remote impl
 		repo := &GithubRepository{
@@ -257,7 +257,7 @@ func TestCreateRepositoryRuleset(t *testing.T) {
 	t.Run("happy path: dry run", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &CreateRepositoryRulesetMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository to the remote impl
 		repo := &GithubRepository{
@@ -304,7 +304,7 @@ func TestCreateRepositoryRuleset(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "Invalid ruleset configuration",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository to the remote impl
 		repo := &GithubRepository{
@@ -384,7 +384,7 @@ func TestDeleteRepositoryRuleset(t *testing.T) {
 	t.Run("happy path: delete existing ruleset", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &DeleteRepositoryRulesetMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository with ruleset to the remote impl
 		repo := &GithubRepository{
@@ -423,7 +423,7 @@ func TestDeleteRepositoryRuleset(t *testing.T) {
 	t.Run("error path: repository not found", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &DeleteRepositoryRulesetMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		remoteImpl.loadRepositories(ctx, nil)
@@ -446,7 +446,7 @@ func TestDeleteRepositoryRuleset(t *testing.T) {
 	t.Run("error path: ruleset not found", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &DeleteRepositoryRulesetMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository without the target ruleset
 		repo := &GithubRepository{
@@ -483,7 +483,7 @@ func TestDeleteRepositoryRuleset(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "failed to delete ruleset",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository with ruleset to the remote impl
 		repo := &GithubRepository{
@@ -519,7 +519,7 @@ func TestDeleteRepositoryRuleset(t *testing.T) {
 	t.Run("happy path: dry run", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &DeleteRepositoryRulesetMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository with ruleset to the remote impl
 		repo := &GithubRepository{
@@ -565,7 +565,7 @@ func TestDeleteRepositoryRuleset(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "Not Found",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository with ruleset to the remote impl
 		repo := &GithubRepository{
@@ -647,7 +647,7 @@ func TestUpdateRepositoryRuleset(t *testing.T) {
 	t.Run("happy path: update existing ruleset", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateRepositoryRulesetMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository with existing ruleset to the remote impl
 		repo := &GithubRepository{
@@ -778,7 +778,7 @@ func TestUpdateRepositoryRuleset(t *testing.T) {
 	t.Run("error path: repository not found", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateRepositoryRulesetMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Setup ruleset for update
 		ruleset := &GithubRuleSet{
@@ -807,7 +807,7 @@ func TestUpdateRepositoryRuleset(t *testing.T) {
 	t.Run("error path: ruleset not found", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateRepositoryRulesetMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository without the target ruleset
 		repo := &GithubRepository{
@@ -850,7 +850,7 @@ func TestUpdateRepositoryRuleset(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "failed to update ruleset",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository with existing ruleset
 		repo := &GithubRepository{
@@ -893,7 +893,7 @@ func TestUpdateRepositoryRuleset(t *testing.T) {
 	t.Run("happy path: dry run", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateRepositoryRulesetMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository with existing ruleset
 		repo := &GithubRepository{
@@ -945,7 +945,7 @@ func TestUpdateRepositoryRuleset(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "Invalid ruleset configuration",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository with existing ruleset
 		repo := &GithubRepository{

--- a/internal/engine/remote_ruleset_test.go
+++ b/internal/engine/remote_ruleset_test.go
@@ -64,7 +64,7 @@ func TestFromGraphQLToGithubRuleset(t *testing.T) {
 	t.Run("happy path: complete ruleset conversion", func(t *testing.T) {
 		// Setup mock client and remote impl
 		mockClient := &RulesetMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Setup test data - GraphQL ruleset
 		graphqlRuleset := &GraphQLGithubRuleSet{
@@ -225,7 +225,7 @@ func TestFromGraphQLToGithubRuleset(t *testing.T) {
 	t.Run("empty ruleset conversion", func(t *testing.T) {
 		// Setup mock client and remote impl
 		mockClient := &RulesetMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Setup minimal test data
 		graphqlRuleset := &GraphQLGithubRuleSet{
@@ -323,7 +323,7 @@ func TestAddRuleset(t *testing.T) {
 	t.Run("happy path: add ruleset", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &AddRulesetMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Setup test data
 		ruleset := &GithubRuleSet{
@@ -454,7 +454,7 @@ func TestAddRuleset(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "failed to create ruleset",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Setup minimal test data
 		ruleset := &GithubRuleSet{
@@ -480,7 +480,7 @@ func TestAddRuleset(t *testing.T) {
 	t.Run("happy path: dry run", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &AddRulesetMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Setup test data
 		ruleset := &GithubRuleSet{
@@ -516,7 +516,7 @@ func TestAddRuleset(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "Invalid ruleset configuration",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Setup test data with invalid configuration
 		ruleset := &GithubRuleSet{
@@ -587,7 +587,7 @@ func TestDeleteRuleset(t *testing.T) {
 	t.Run("happy path: delete existing ruleset", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &DeleteRulesetMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add a ruleset to the cache
 		ruleset := &GithubRuleSet{
@@ -623,7 +623,7 @@ func TestDeleteRuleset(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "ruleset not found",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add a ruleset to the cache
 		ruleset := &GithubRuleSet{
@@ -653,7 +653,7 @@ func TestDeleteRuleset(t *testing.T) {
 	t.Run("happy path: dry run", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &DeleteRulesetMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add a ruleset to the cache
 		ruleset := &GithubRuleSet{
@@ -688,7 +688,7 @@ func TestDeleteRuleset(t *testing.T) {
 	t.Run("happy path: delete non-existent ruleset ID", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &DeleteRulesetMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add a ruleset to the cache with different ID
 		ruleset := &GithubRuleSet{
@@ -720,7 +720,7 @@ func TestDeleteRuleset(t *testing.T) {
 	t.Run("error path: delete with multiple rulesets in cache", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &DeleteRulesetMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add multiple rulesets to the cache
 		ruleset1 := &GithubRuleSet{
@@ -805,7 +805,7 @@ func TestUpdateRuleset(t *testing.T) {
 	t.Run("happy path: update existing ruleset", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateRulesetMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Setup test data
 		ruleset := &GithubRuleSet{
@@ -943,7 +943,7 @@ func TestUpdateRuleset(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "failed to update ruleset",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Setup test data
 		ruleset := &GithubRuleSet{
@@ -979,7 +979,7 @@ func TestUpdateRuleset(t *testing.T) {
 	t.Run("happy path: dry run", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateRulesetMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Setup test data
 		ruleset := &GithubRuleSet{
@@ -1024,7 +1024,7 @@ func TestUpdateRuleset(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "Invalid ruleset configuration",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Setup test data with invalid configuration
 		ruleset := &GithubRuleSet{
@@ -1060,7 +1060,7 @@ func TestUpdateRuleset(t *testing.T) {
 	t.Run("error path: non-existent ruleset", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateRulesetMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Setup test data for a ruleset that doesn't exist in cache
 		ruleset := &GithubRuleSet{

--- a/internal/engine/remote_team_test.go
+++ b/internal/engine/remote_team_test.go
@@ -66,7 +66,7 @@ func TestCreateTeam(t *testing.T) {
 	t.Run("happy path: create team", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &CreateTeamMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
@@ -98,7 +98,7 @@ func TestCreateTeam(t *testing.T) {
 	t.Run("happy path: create team with members", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &CreateTeamMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
@@ -129,7 +129,7 @@ func TestCreateTeam(t *testing.T) {
 	t.Run("error path: team already exists", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &CreateTeamMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add existing team to the cache
 		remoteImpl.teams = map[string]*GithubTeam{
@@ -162,7 +162,7 @@ func TestCreateTeam(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "failed to create team",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
@@ -181,7 +181,7 @@ func TestCreateTeam(t *testing.T) {
 	t.Run("happy path: dry run", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &CreateTeamMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		remoteImpl.loadTeams(ctx)
@@ -209,7 +209,7 @@ func TestCreateTeam(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "Parent team does not exist",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
@@ -233,7 +233,7 @@ func TestCreateTeam(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "Invalid team name",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		logsCollector := observability.NewLogCollection()
@@ -299,7 +299,7 @@ func TestDeleteTeam(t *testing.T) {
 	t.Run("happy path: delete existing team", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &DeleteTeamMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add team to the cache
 		remoteImpl.teams = map[string]*GithubTeam{
@@ -330,7 +330,7 @@ func TestDeleteTeam(t *testing.T) {
 	t.Run("error path: team not found in cache", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &DeleteTeamMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		remoteImpl.loadTeams(ctx)
@@ -354,7 +354,7 @@ func TestDeleteTeam(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "failed to delete team",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add team to the cache
 		remoteImpl.teams = map[string]*GithubTeam{
@@ -382,7 +382,7 @@ func TestDeleteTeam(t *testing.T) {
 	t.Run("happy path: dry run", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &DeleteTeamMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add team to the cache
 		remoteImpl.teams = map[string]*GithubTeam{
@@ -418,7 +418,7 @@ func TestDeleteTeam(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "Not Found",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add team to the cache
 		remoteImpl.teams = map[string]*GithubTeam{
@@ -450,7 +450,7 @@ func TestDeleteTeam(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "Cannot delete team with repositories",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add team to the cache
 		remoteImpl.teams = map[string]*GithubTeam{
@@ -530,7 +530,7 @@ func TestUpdateTeamAddMember(t *testing.T) {
 	t.Run("happy path: add member to team", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateTeamAddMemberMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add team to the cache
 		remoteImpl.teams = map[string]*GithubTeam{
@@ -566,7 +566,7 @@ func TestUpdateTeamAddMember(t *testing.T) {
 	t.Run("happy path: add maintainer to team", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateTeamAddMemberMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add team to the cache
 		remoteImpl.teams = map[string]*GithubTeam{
@@ -600,7 +600,7 @@ func TestUpdateTeamAddMember(t *testing.T) {
 	t.Run("error path: team not found", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateTeamAddMemberMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		remoteImpl.loadTeams(ctx)
@@ -652,7 +652,7 @@ func TestUpdateTeamAddMember(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "failed to add member to team",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add team to the cache
 		remoteImpl.teams = map[string]*GithubTeam{
@@ -679,7 +679,7 @@ func TestUpdateTeamAddMember(t *testing.T) {
 	t.Run("happy path: dry run", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateTeamAddMemberMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add team to the cache
 		remoteImpl.teams = map[string]*GithubTeam{
@@ -708,7 +708,7 @@ func TestUpdateTeamAddMember(t *testing.T) {
 	t.Run("error path: empty username", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateTeamAddMemberMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add team to the cache
 		remoteImpl.teams = map[string]*GithubTeam{
@@ -785,7 +785,7 @@ func TestUpdateTeamRemoveMember(t *testing.T) {
 	t.Run("happy path: remove member from team", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateTeamRemoveMemberMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add team to the cache
 		remoteImpl.teams = map[string]*GithubTeam{
@@ -813,7 +813,7 @@ func TestUpdateTeamRemoveMember(t *testing.T) {
 	t.Run("error path: team not found", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateTeamRemoveMemberMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		remoteImpl.loadTeams(ctx)
@@ -837,7 +837,7 @@ func TestUpdateTeamRemoveMember(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "failed to remove member from team",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add team to the cache
 		remoteImpl.teams = map[string]*GithubTeam{
@@ -862,7 +862,7 @@ func TestUpdateTeamRemoveMember(t *testing.T) {
 	t.Run("happy path: dry run", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateTeamRemoveMemberMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add team to the cache
 		remoteImpl.teams = map[string]*GithubTeam{
@@ -891,7 +891,7 @@ func TestUpdateTeamRemoveMember(t *testing.T) {
 	t.Run("error path: empty username", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateTeamRemoveMemberMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add team to the cache
 		remoteImpl.teams = map[string]*GithubTeam{
@@ -925,7 +925,7 @@ func TestUpdateTeamRemoveMember(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "Not Found",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add team to the cache
 		remoteImpl.teams = map[string]*GithubTeam{
@@ -1002,7 +1002,7 @@ func TestUpdateTeamUpdateMember(t *testing.T) {
 	t.Run("happy path: update member role to maintainer", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateTeamUpdateMemberMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add team to the cache
 		remoteImpl.teams = map[string]*GithubTeam{
@@ -1036,7 +1036,7 @@ func TestUpdateTeamUpdateMember(t *testing.T) {
 	t.Run("happy path: update member role to member", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateTeamUpdateMemberMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add team to the cache
 		remoteImpl.teams = map[string]*GithubTeam{
@@ -1070,7 +1070,7 @@ func TestUpdateTeamUpdateMember(t *testing.T) {
 	t.Run("error path: team not found", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateTeamUpdateMemberMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		remoteImpl.loadTeams(ctx)
@@ -1122,7 +1122,7 @@ func TestUpdateTeamUpdateMember(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "failed to update team member",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add team to the cache
 		remoteImpl.teams = map[string]*GithubTeam{
@@ -1147,7 +1147,7 @@ func TestUpdateTeamUpdateMember(t *testing.T) {
 	t.Run("happy path: dry run", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateTeamUpdateMemberMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add team to the cache
 		remoteImpl.teams = map[string]*GithubTeam{
@@ -1176,7 +1176,7 @@ func TestUpdateTeamUpdateMember(t *testing.T) {
 	t.Run("error path: empty username", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateTeamUpdateMemberMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add team to the cache
 		remoteImpl.teams = map[string]*GithubTeam{
@@ -1210,7 +1210,7 @@ func TestUpdateTeamUpdateMember(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "Not Found",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add team to the cache
 		remoteImpl.teams = map[string]*GithubTeam{
@@ -1282,7 +1282,7 @@ func TestUpdateRepositoryAddTeamAccess(t *testing.T) {
 	t.Run("happy path: add team access with pull permission", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateRepositoryAddTeamAccessMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository and team to the cache
 		remoteImpl.repositories = map[string]*GithubRepository{
@@ -1325,7 +1325,7 @@ func TestUpdateRepositoryAddTeamAccess(t *testing.T) {
 	t.Run("happy path: add team access with push permission", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateRepositoryAddTeamAccessMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository and team to the cache
 		remoteImpl.repositories = map[string]*GithubRepository{
@@ -1365,7 +1365,7 @@ func TestUpdateRepositoryAddTeamAccess(t *testing.T) {
 	t.Run("error path: repository not found", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateRepositoryAddTeamAccessMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add only team to the cache
 		remoteImpl.teams = map[string]*GithubTeam{
@@ -1396,7 +1396,7 @@ func TestUpdateRepositoryAddTeamAccess(t *testing.T) {
 	t.Run("error path: team not found", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateRepositoryAddTeamAccessMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add only repository to the cache
 		remoteImpl.repositories = map[string]*GithubRepository{
@@ -1466,7 +1466,7 @@ func TestUpdateRepositoryAddTeamAccess(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "failed to add team access",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		remoteImpl.loadRepositories(ctx, nil)
@@ -1500,7 +1500,7 @@ func TestUpdateRepositoryAddTeamAccess(t *testing.T) {
 	t.Run("happy path: dry run", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateRepositoryAddTeamAccessMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		remoteImpl.loadRepositories(ctx, nil)
@@ -1583,7 +1583,7 @@ func TestUpdateRepositoryUpdateTeamAccess(t *testing.T) {
 	t.Run("happy path: update team access to pull permission", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateRepositoryUpdateTeamAccessMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		remoteImpl.loadTeams(ctx)
@@ -1626,7 +1626,7 @@ func TestUpdateRepositoryUpdateTeamAccess(t *testing.T) {
 	t.Run("happy path: update team access to push permission", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateRepositoryUpdateTeamAccessMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository and team to the cache
 		remoteImpl.repositories = map[string]*GithubRepository{
@@ -1666,7 +1666,7 @@ func TestUpdateRepositoryUpdateTeamAccess(t *testing.T) {
 	t.Run("happy path: update team access to admin permission", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateRepositoryUpdateTeamAccessMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		// Add repository and team to the cache
 		remoteImpl.repositories = map[string]*GithubRepository{
@@ -1706,7 +1706,7 @@ func TestUpdateRepositoryUpdateTeamAccess(t *testing.T) {
 	t.Run("error path: repository not found", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateRepositoryUpdateTeamAccessMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		remoteImpl.loadTeams(ctx)
@@ -1737,7 +1737,7 @@ func TestUpdateRepositoryUpdateTeamAccess(t *testing.T) {
 	t.Run("error path: team not found", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateRepositoryUpdateTeamAccessMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		remoteImpl.loadRepositories(ctx, nil)
@@ -1804,7 +1804,7 @@ func TestUpdateRepositoryUpdateTeamAccess(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "failed to update team access",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		remoteImpl.loadRepositories(ctx, nil)
@@ -1838,7 +1838,7 @@ func TestUpdateRepositoryUpdateTeamAccess(t *testing.T) {
 	t.Run("happy path: dry run", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateRepositoryUpdateTeamAccessMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		remoteImpl.loadRepositories(ctx, nil)
@@ -1921,7 +1921,7 @@ func TestUpdateRepositoryRemoveTeamAccess(t *testing.T) {
 	t.Run("happy path: remove team access", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateRepositoryRemoveTeamAccessMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		remoteImpl.loadRepositories(ctx, nil)
@@ -1958,7 +1958,7 @@ func TestUpdateRepositoryRemoveTeamAccess(t *testing.T) {
 	t.Run("error path: repository not found", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateRepositoryRemoveTeamAccessMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		remoteImpl.loadTeams(ctx)
@@ -1988,7 +1988,7 @@ func TestUpdateRepositoryRemoveTeamAccess(t *testing.T) {
 	t.Run("error path: team not found", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateRepositoryRemoveTeamAccessMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		remoteImpl.loadRepositories(ctx, nil)
@@ -2020,7 +2020,7 @@ func TestUpdateRepositoryRemoveTeamAccess(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "failed to remove team access",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		remoteImpl.loadRepositories(ctx, nil)
@@ -2054,7 +2054,7 @@ func TestUpdateRepositoryRemoveTeamAccess(t *testing.T) {
 	t.Run("happy path: dry run", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &UpdateRepositoryRemoveTeamAccessMockClient{}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		remoteImpl.loadRepositories(ctx, nil)
@@ -2094,7 +2094,7 @@ func TestUpdateRepositoryRemoveTeamAccess(t *testing.T) {
 			shouldError:  true,
 			errorMessage: "Not Found",
 		}
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		remoteImpl.loadRepositories(ctx, nil)

--- a/internal/engine/remote_test.go
+++ b/internal/engine/remote_test.go
@@ -454,7 +454,7 @@ func TestRemoteRepository(t *testing.T) {
 		// MockGithubClient doesn't support concurrent access
 		client := MockGithubClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(&client, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(&client, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		repositories, _, err := remoteImpl.loadRepositories(ctx, nil)
@@ -469,7 +469,7 @@ func TestRemoteRepository(t *testing.T) {
 		// MockGithubClient doesn't support concurrent access
 		client := MockGithubClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(&client, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(&client, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		teams, _, err := remoteImpl.loadTeams(ctx)
@@ -482,7 +482,7 @@ func TestRemoteRepository(t *testing.T) {
 		// MockGithubClient doesn't support concurrent access
 		client := MockGithubClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(&client, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(&client, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		repo_0 := &GithubRepository{
@@ -500,7 +500,7 @@ func TestRemoteRepository(t *testing.T) {
 		// MockGithubClient doesn't support concurrent access
 		client := MockGithubClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(&client, "myorg", true, true)
+		remoteImpl := NewGoliacRemoteImpl(&client, "myorg", true, true, true)
 
 		ctx := context.TODO()
 		err := remoteImpl.Load(ctx, false)
@@ -643,7 +643,7 @@ func TestIsEnterprise(t *testing.T) {
 func TestPrepareRuleset(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		ghClient := MockGithubClient{}
-		g := NewGoliacRemoteImpl(&ghClient, "myorg", true, true)
+		g := NewGoliacRemoteImpl(&ghClient, "myorg", true, true, true)
 		g.appIds["goliac-project-app"] = &GithubApp{
 			Id:        1,
 			GraphqlId: "123",
@@ -691,7 +691,7 @@ repositories:
 
 	t.Run("happy path: non default branch name", func(t *testing.T) {
 		ghClient := MockGithubClient{}
-		g := NewGoliacRemoteImpl(&ghClient, "myorg", true, true)
+		g := NewGoliacRemoteImpl(&ghClient, "myorg", true, true, true)
 		g.appIds["goliac-project-app"] = &GithubApp{
 			Id:        1,
 			GraphqlId: "123",

--- a/internal/goliac.go
+++ b/internal/goliac.go
@@ -98,6 +98,7 @@ func NewGoliacImpl() (Goliac, error) {
 		config.Config.GithubAppOrganization,
 		config.Config.ManageGithubActionsVariables,
 		config.Config.ManageGithubAutolinks,
+		config.Config.ManageOrgCustomProperties,
 	)
 
 	usersync.InitPlugins(remoteGithubClient)

--- a/internal/scaffold.go
+++ b/internal/scaffold.go
@@ -42,7 +42,7 @@ func NewScaffold() (*Scaffold, error) {
 		return nil, err
 	}
 
-	remote := engine.NewGoliacRemoteImpl(githubClient, config.Config.GithubAppOrganization, config.Config.ManageGithubActionsVariables, config.Config.ManageGithubAutolinks)
+	remote := engine.NewGoliacRemoteImpl(githubClient, config.Config.GithubAppOrganization, config.Config.ManageGithubActionsVariables, config.Config.ManageGithubAutolinks, config.Config.ManageOrgCustomProperties)
 
 	loadUsersFromGithubOrgSaml := func(feedback observability.RemoteObservability) (map[string]*entity.User, error) {
 		ctx := context.Background()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a flag to enable/disable organization custom properties management and fixes branch protection comparison/update edge cases.
> 
> - **Config/Remote**:
>   - Add `GOLIAC_MANAGE_ORG_CUSTOM_PROPERTIES` env and `ManageOrgCustomProperties` config; thread through `NewGoliacRemoteImpl` and callers (`internal/goliac.go`, `internal/scaffold.go`).
>   - Update `GoliacRemoteImpl` to conditionally load repository custom properties based on the flag.
>   - Adjust tests to new `NewGoliacRemoteImpl` signature.
> - **Branch Protection Fixes**:
>   - Only compare `dismissesStaleReviews`/`requiresCodeOwnerReviews`/`requireLastPushApproval` when `requiresApprovingReviews` is true.
>   - When updating, send empty `requiredStatusCheckContexts` if nil.
> - **Docs/Changelog**:
>   - Bump to `v1.5.2`; document new env var and branch protection fixes in `CHANGELOG.md` and `docs/installation.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aac03e0ff5b512257773389035475d60a75206fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->