### PR TITLE
V1 6 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Goliac v1.6.0
+
+- add support for topics
+- better Github rate limiting support
+
 ## Goliac v1.5.2
 
 - custom properties scan can be disabled

--- a/docs/resource_repository.md
+++ b/docs/resource_repository.md
@@ -325,6 +325,23 @@ spec:
   autolinks: []
 ```
 
+## Repository topics
+
+You can set topics (tags) on a repository to help categorize and discover repositories:
+
+```yaml
+apiVersion: v1
+kind: Repository
+name: awesome-repository
+spec:
+  topics:
+    - golang
+    - microservices
+    - api
+```
+
+Topics are displayed on the repository page on GitHub and can be used for searching and filtering repositories.
+
 ## Custom properties
 
 You can set custom properties in the repository definition. Custom properties can be strings or arrays of strings.

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -12,7 +12,7 @@ var Config = struct {
 	GithubServer              string `env:"GOLIAC_GITHUB_SERVER" envDefault:"https://api.github.com"`
 	GithubAppOrganization     string `env:"GOLIAC_GITHUB_APP_ORGANIZATION" envDefault:""`
 	GithubAppID               int64  `env:"GOLIAC_GITHUB_APP_ID"`
-	GithubAppPrivateKeyFile   string `env:"GOLIAC_GITHUB_APP_PRIVATE_KEY_FILE" envDefault:"github-app-private-key.pem"`
+	GithubAppPrivateKeyFile   string `env:"GOLIAC_GITHUB_APP_PRIVATE_KEY_FILE" envDefault:""`
 	GithubAppClientSecret     string `env:"GOLIAC_GITHUB_APP_CLIENT_SECRET"`
 	GithubAppCallbackURL      string `env:"GOLIAC_GITHUB_APP_CALLBACK_URL"`
 	GithubPersonalAccessToken string `env:"GOLIAC_GITHUB_PERSONAL_ACCESS_TOKEN"`

--- a/internal/engine/goliac_reconciliator_datasource.go
+++ b/internal/engine/goliac_reconciliator_datasource.go
@@ -349,6 +349,7 @@ func (d *GoliacReconciliatorDatasourceLocal) Repositories() (map[string]*GithubR
 			DefaultMergeCommitMessage:  lRepo.Spec.DefaultMergeCommitMessage,
 			DefaultSquashCommitMessage: lRepo.Spec.DefaultSquashCommitMessage,
 			CustomProperties:           customProps,
+			Topics:                     lRepo.Spec.Topics,
 			IsFork:                     lRepo.ForkFrom != "",
 			ForkFrom:                   lRepo.ForkFrom,
 		})
@@ -503,6 +504,7 @@ func (d *GoliacReconciliatorDatasourceRemote) Repositories() (map[string]*Github
 			DefaultMergeCommitMessage:  v.DefaultMergeCommitMessage,
 			DefaultSquashCommitMessage: v.DefaultSquashCommitMessage,
 			CustomProperties:           make(map[string]interface{}),
+			Topics:                     v.Topics,
 			IsFork:                     v.IsFork,
 		}
 		for pk, pv := range v.BoolProperties {

--- a/internal/engine/goliac_reconciliator_test.go
+++ b/internal/engine/goliac_reconciliator_test.go
@@ -305,6 +305,9 @@ func (r *ReconciliatorListenerRecorder) UpdateRepositoryUpdateProperties(ctx con
 func (r *ReconciliatorListenerRecorder) UpdateRepositoryCustomProperties(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, propertyName string, propertyValue interface{}) {
 	// Track custom property updates if needed for testing
 }
+func (r *ReconciliatorListenerRecorder) UpdateRepositoryTopics(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, topics []string) {
+	// Track topics updates if needed for testing
+}
 func (r *ReconciliatorListenerRecorder) UpdateRepositorySetExternalUser(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, githubid string, permission string) {
 	r.RepositoriesSetExternalUser[githubid] = permission
 }

--- a/internal/engine/mutable_remote.go
+++ b/internal/engine/mutable_remote.go
@@ -303,6 +303,7 @@ func (m *MutableGoliacRemoteImpl) CreateRepository(reponame string, descrition s
 		BranchProtections:   make(map[string]*GithubBranchProtection),
 		Environments:        NewMutableEnvironmentLazyLoader(nil),
 		ActionVariables:     NewMutableRepositoryVariableLazyLoader(nil),
+		Topics:              []string{},
 	}
 	m.repositories[reponame] = &r
 }
@@ -433,6 +434,12 @@ func (m *MutableGoliacRemoteImpl) UpdateRepositoryCustomProperties(reponame stri
 			r.CustomProperties = make(map[string]interface{})
 		}
 		r.CustomProperties[propertyName] = propertyValue
+	}
+}
+
+func (m *MutableGoliacRemoteImpl) UpdateRepositoryTopics(reponame string, topics []string) {
+	if r, ok := m.repositories[reponame]; ok {
+		r.Topics = topics
 	}
 }
 

--- a/internal/engine/reconciliator_executor.go
+++ b/internal/engine/reconciliator_executor.go
@@ -22,6 +22,7 @@ type ReconciliatorExecutor interface {
 	CreateRepository(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, descrition string, visibility string, writers []string, readers []string, boolProperties map[string]bool, defaultBranch string, githubToken *string, forkFrom string)
 	UpdateRepositoryUpdateProperties(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, properties map[string]interface{})
 	UpdateRepositoryCustomProperties(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, propertyName string, propertyValue interface{})
+	UpdateRepositoryTopics(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, topics []string)
 	UpdateRepositoryAddTeamAccess(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, teamslug string, permission string)    // permission can be "pull", "push", or "admin" which correspond to read, write, and admin access.
 	UpdateRepositoryUpdateTeamAccess(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, teamslug string, permission string) // permission can be "pull", "push", or "admin" which correspond to read, write, and admin access.
 	UpdateRepositoryRemoveTeamAccess(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, teamslug string)

--- a/internal/entity/repository.go
+++ b/internal/entity/repository.go
@@ -47,6 +47,7 @@ type Repository struct {
 		ActionsVariables           map[string]string            `yaml:"actions_variables,omitempty"`
 		Autolinks                  *[]RepositoryAutolink        `yaml:"autolinks,omitempty"`
 		CustomProperties           map[string]interface{}       `yaml:"custom_properties,omitempty"`
+		Topics                     []string                     `yaml:"topics,omitempty"`
 	} `yaml:"spec,omitempty"`
 	Archived      bool    `yaml:"archived,omitempty"` // implicit: will be set by Goliac
 	Owner         *string `yaml:"-"`                  // implicit. team name owning the repo (if any)

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -273,7 +273,7 @@ func (client *GitHubClientImpl) QueryGraphQLAPI(ctx context.Context, query strin
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusForbidden {
+	if resp.StatusCode == http.StatusTooManyRequests || (resp.StatusCode == http.StatusForbidden && resp.Header.Get("X-Ratelimit-Remaining") == "0") {
 		if stats != nil {
 			goliacStats := stats.(*config.GoliacStatistics)
 			goliacStats.GithubThrottled++
@@ -418,7 +418,7 @@ func (client *GitHubClientImpl) CallRestAPI(ctx context.Context, endpoint, param
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusTooManyRequests {
+	if resp.StatusCode == http.StatusTooManyRequests || (resp.StatusCode == http.StatusForbidden && resp.Header.Get("X-Ratelimit-Remaining") == "0") {
 		if stats != nil {
 			goliacStats := stats.(*config.GoliacStatistics)
 			goliacStats.GithubThrottled++

--- a/internal/github_batch_executor.go
+++ b/internal/github_batch_executor.go
@@ -182,6 +182,15 @@ func (g *GithubBatchExecutor) UpdateRepositoryCustomProperties(ctx context.Conte
 	})
 }
 
+func (g *GithubBatchExecutor) UpdateRepositoryTopics(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, topics []string) {
+	g.commands = append(g.commands, &GithubCommandUpdateRepositoryTopics{
+		client:   g.client,
+		dryrun:   dryrun,
+		reponame: reponame,
+		topics:   topics,
+	})
+}
+
 func (g *GithubBatchExecutor) UpdateRepositorySetExternalUser(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, githubid string, permission string) {
 	g.commands = append(g.commands, &GithubCommandUpdateRepositorySetExternalUser{
 		client:     g.client,
@@ -615,6 +624,17 @@ type GithubCommandUpdateRepositoryCustomProperties struct {
 
 func (g *GithubCommandUpdateRepositoryCustomProperties) Apply(ctx context.Context, logsCollector *observability.LogCollection) {
 	g.client.UpdateRepositoryCustomProperties(ctx, logsCollector, g.dryrun, g.reponame, g.propertyName, g.propertyValue)
+}
+
+type GithubCommandUpdateRepositoryTopics struct {
+	client   engine.ReconciliatorExecutor
+	dryrun   bool
+	reponame string
+	topics   []string
+}
+
+func (g *GithubCommandUpdateRepositoryTopics) Apply(ctx context.Context, logsCollector *observability.LogCollection) {
+	g.client.UpdateRepositoryTopics(ctx, logsCollector, g.dryrun, g.reponame, g.topics)
 }
 
 type GithubCommandUpdateTeamAddMember struct {

--- a/internal/goliac_test.go
+++ b/internal/goliac_test.go
@@ -641,6 +641,10 @@ func (e *GoliacRemoteExecutorMock) UpdateRepositoryCustomProperties(ctx context.
 	fmt.Println("*** UpdateRepositoryCustomProperties", reponame, propertyName, propertyValue)
 	e.nbChanges++
 }
+func (e *GoliacRemoteExecutorMock) UpdateRepositoryTopics(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, topics []string) {
+	fmt.Println("*** UpdateRepositoryTopics", reponame, topics)
+	e.nbChanges++
+}
 func (e *GoliacRemoteExecutorMock) UpdateRepositoryAddTeamAccess(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, teamslug string, permission string) {
 	fmt.Println("*** UpdateRepositoryAddTeamAccess", reponame, teamslug, permission)
 	e.nbChanges++

--- a/internal/scaffold.go
+++ b/internal/scaffold.go
@@ -522,6 +522,10 @@ func (s *Scaffold) generateTeams(ctx context.Context, fs billy.Filesystem, teams
 							lRepo.Spec.CustomProperties[propName] = propValue
 						}
 					}
+					// scaffold topics
+					if len(rRepo.Topics) > 0 {
+						lRepo.Spec.Topics = rRepo.Topics
+					}
 				}
 
 				if lRepo.Archived {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add repository topics support (spec, reconciliation, remote APIs, scaffold) and improve GitHub rate limit detection; adjust GitHub App private key env default.
> 
> - **Repository Topics (new)**:
>   - Add `spec.topics` to repository schema (`internal/entity/repository.go`) and docs (`docs/resource_repository.md`).
>   - Load topics via GraphQL `repositoryTopics` and expose on `GithubRepository` (`internal/engine/remote.go`).
>   - Compare/reconcile topics and update via REST `PUT /repos/{org}/{repo}/topics` (`internal/engine/goliac_reconciliator.go`, `internal/engine/remote.go`).
>   - Wire through datasource, mutable remote, executor, batch executor, and tests.
>   - Scaffold includes existing repository `topics` in generated YAML (`internal/scaffold.go`).
> - **GitHub rate limiting**:
>   - Treat `403` with `X-Ratelimit-Remaining: 0` as throttled in GraphQL/REST client (`internal/github/client.go`).
> - **Config**:
>   - Change default `GOLIAC_GITHUB_APP_PRIVATE_KEY_FILE` to empty string (`internal/config/env.go`).
> - **Changelog**: Add `v1.6.0` with topics and rate limiting notes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 906cb4808f70f4e1c9186f922e516e3156ef28bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->