### PR TITLE
V1 6 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Goliac v1.6.1
+
+- bugfix: fix Github rate limiting headers case
+- add branch protection bypass user validation
+
 ## Goliac v1.6.0
 
 - add support for topics

--- a/internal/entity/repository_test.go
+++ b/internal/entity/repository_test.go
@@ -71,7 +71,7 @@ name: repo1
 		assert.False(t, logsCollector.HasWarns())
 		assert.NotNil(t, teams)
 
-		repos := ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, []*config.GithubCustomProperty{}, logsCollector)
+		repos := ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, users, []*config.GithubCustomProperty{}, logsCollector)
 		assert.False(t, logsCollector.HasErrors())
 		assert.False(t, logsCollector.HasWarns())
 		assert.NotNil(t, repos)
@@ -99,7 +99,7 @@ name: repo2
 		assert.False(t, logsCollector.HasWarns())
 		assert.NotNil(t, teams)
 
-		ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, []*config.GithubCustomProperty{}, logsCollector)
+		ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, users, []*config.GithubCustomProperty{}, logsCollector)
 		assert.True(t, logsCollector.HasErrors())
 		assert.False(t, logsCollector.HasWarns())
 	})
@@ -129,7 +129,7 @@ spec:
 		assert.False(t, logsCollector.HasWarns())
 		assert.NotNil(t, teams)
 
-		ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, []*config.GithubCustomProperty{}, logsCollector)
+		ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, users, []*config.GithubCustomProperty{}, logsCollector)
 		assert.True(t, logsCollector.HasErrors())
 		assert.False(t, logsCollector.HasWarns())
 	})
@@ -159,7 +159,7 @@ spec:
 		assert.False(t, logsCollector.HasWarns())
 		assert.NotNil(t, teams)
 
-		ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, []*config.GithubCustomProperty{}, logsCollector)
+		ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, users, []*config.GithubCustomProperty{}, logsCollector)
 		assert.True(t, logsCollector.HasErrors())
 		assert.False(t, logsCollector.HasWarns())
 	})
@@ -188,7 +188,7 @@ spec:
 		assert.False(t, logsCollector.HasWarns())
 		assert.NotNil(t, teams)
 
-		repos := ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, []*config.GithubCustomProperty{}, logsCollector)
+		repos := ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, users, []*config.GithubCustomProperty{}, logsCollector)
 		assert.False(t, logsCollector.HasErrors())
 		assert.False(t, logsCollector.HasWarns())
 		assert.NotNil(t, repos)
@@ -217,10 +217,266 @@ name: repo1
 		assert.False(t, logsCollector.HasWarns())
 		assert.NotNil(t, teams)
 
-		repos := ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, []*config.GithubCustomProperty{}, logsCollector)
+		repos := ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, users, []*config.GithubCustomProperty{}, logsCollector)
 		assert.False(t, logsCollector.HasErrors())
 		assert.False(t, logsCollector.HasWarns())
 		assert.NotNil(t, repos)
 		assert.Equal(t, len(repos), 1)
+	})
+
+	t.Run("not happy path: invalid bypass_pullrequest_user", func(t *testing.T) {
+		// create a new user
+		fs := memfs.New()
+		fixtureCreateUserTeam(t, fs)
+
+		err := utils.WriteFile(fs, "teams/team1/repo1.yaml", []byte(`
+apiVersion: v1
+kind: Repository
+name: repo1
+spec:
+  branch_protections:
+    - pattern: main
+      bypass_pullrequest_users:
+        - nonexistentuser
+`), 0644)
+		assert.Nil(t, err)
+		logsCollector := observability.NewLogCollection()
+		users := ReadUserDirectory(fs, "users", logsCollector)
+		assert.False(t, logsCollector.HasErrors())
+		assert.False(t, logsCollector.HasWarns())
+		assert.NotNil(t, users)
+
+		teams := ReadTeamDirectory(fs, "teams", users, logsCollector)
+		assert.False(t, logsCollector.HasErrors())
+		assert.False(t, logsCollector.HasWarns())
+		assert.NotNil(t, teams)
+
+		ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, users, []*config.GithubCustomProperty{}, logsCollector)
+		assert.True(t, logsCollector.HasErrors())
+		assert.False(t, logsCollector.HasWarns())
+	})
+
+	t.Run("happy path: valid bypass_pullrequest_user", func(t *testing.T) {
+		// create a new user
+		fs := memfs.New()
+		fixtureCreateUserTeam(t, fs)
+
+		err := utils.WriteFile(fs, "teams/team1/repo1.yaml", []byte(`
+apiVersion: v1
+kind: Repository
+name: repo1
+spec:
+  branch_protections:
+    - pattern: main
+      bypass_pullrequest_users:
+        - user1
+`), 0644)
+		assert.Nil(t, err)
+		logsCollector := observability.NewLogCollection()
+		users := ReadUserDirectory(fs, "users", logsCollector)
+		assert.False(t, logsCollector.HasErrors())
+		assert.False(t, logsCollector.HasWarns())
+		assert.NotNil(t, users)
+
+		teams := ReadTeamDirectory(fs, "teams", users, logsCollector)
+		assert.False(t, logsCollector.HasErrors())
+		assert.False(t, logsCollector.HasWarns())
+		assert.NotNil(t, teams)
+
+		repos := ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, users, []*config.GithubCustomProperty{}, logsCollector)
+		assert.False(t, logsCollector.HasErrors())
+		assert.False(t, logsCollector.HasWarns())
+		assert.NotNil(t, repos)
+		assert.Equal(t, 1, len(repos))
+	})
+
+	t.Run("happy path: valid bypass_pullrequest_user (external user)", func(t *testing.T) {
+		// create a new user
+		fs := memfs.New()
+		fixtureCreateUserTeam(t, fs)
+
+		// create external user
+		fs.MkdirAll("users/external", 0755)
+		err := utils.WriteFile(fs, "users/external/externaluser1.yaml", []byte(`
+apiVersion: v1
+kind: User
+name: externaluser1
+spec:
+  githubID: externalgithub1
+`), 0644)
+		assert.Nil(t, err)
+
+		err = utils.WriteFile(fs, "teams/team1/repo1.yaml", []byte(`
+apiVersion: v1
+kind: Repository
+name: repo1
+spec:
+  branch_protections:
+    - pattern: main
+      bypass_pullrequest_users:
+        - externaluser1
+`), 0644)
+		assert.Nil(t, err)
+		logsCollector := observability.NewLogCollection()
+		users := ReadUserDirectory(fs, "users", logsCollector)
+		assert.False(t, logsCollector.HasErrors())
+		assert.False(t, logsCollector.HasWarns())
+		assert.NotNil(t, users)
+
+		externalUsers := ReadUserDirectory(fs, "users/external", logsCollector)
+		assert.False(t, logsCollector.HasErrors())
+		assert.False(t, logsCollector.HasWarns())
+		assert.NotNil(t, externalUsers)
+
+		teams := ReadTeamDirectory(fs, "teams", users, logsCollector)
+		assert.False(t, logsCollector.HasErrors())
+		assert.False(t, logsCollector.HasWarns())
+		assert.NotNil(t, teams)
+
+		repos := ReadRepositories(fs, "archived", "teams", teams, externalUsers, users, []*config.GithubCustomProperty{}, logsCollector)
+		assert.False(t, logsCollector.HasErrors())
+		assert.False(t, logsCollector.HasWarns())
+		assert.NotNil(t, repos)
+		assert.Equal(t, 1, len(repos))
+	})
+}
+
+func TestReadAndAdjustRepositories(t *testing.T) {
+	t.Run("happy path: no repositories, no problem", func(t *testing.T) {
+		fs := memfs.New()
+		users := make(map[string]*User)
+		externalUsers := make(map[string]*User)
+
+		changed, err := ReadAndAdjustRepositories(fs, "archived", "teams", users, externalUsers)
+		assert.Nil(t, err)
+		assert.Equal(t, 0, len(changed))
+	})
+
+	t.Run("happy path: no change needed", func(t *testing.T) {
+		fs := memfs.New()
+		users := make(map[string]*User)
+		user1 := &User{}
+		user1.Name = "user1"
+		user1.Spec.GithubID = "github1"
+		users["user1"] = user1
+
+		fs.MkdirAll("teams/team1", 0755)
+		err := utils.WriteFile(fs, "teams/team1/repo1.yaml", []byte(`
+apiVersion: v1
+kind: Repository
+name: repo1
+spec:
+  branch_protections:
+    - pattern: main
+      bypass_pullrequest_users:
+        - user1
+`), 0644)
+		assert.Nil(t, err)
+
+		changed, err := ReadAndAdjustRepositories(fs, "archived", "teams", users, map[string]*User{})
+		assert.Nil(t, err)
+		assert.Equal(t, 0, len(changed))
+	})
+
+	t.Run("happy path: remove deleted user from bypass_pullrequest_users", func(t *testing.T) {
+		fs := memfs.New()
+		users := make(map[string]*User)
+		// user1 exists, user2 doesn't
+		user1 := &User{}
+		user1.Name = "user1"
+		user1.Spec.GithubID = "github1"
+		users["user1"] = user1
+
+		fs.MkdirAll("teams/team1", 0755)
+		err := utils.WriteFile(fs, "teams/team1/repo1.yaml", []byte(`
+apiVersion: v1
+kind: Repository
+name: repo1
+spec:
+  branch_protections:
+    - pattern: main
+      bypass_pullrequest_users:
+        - user1
+        - user2
+`), 0644)
+		assert.Nil(t, err)
+
+		changed, err := ReadAndAdjustRepositories(fs, "archived", "teams", users, map[string]*User{})
+		assert.Nil(t, err)
+		assert.Equal(t, 1, len(changed))
+
+		// Verify the file was updated
+		content, err := utils.ReadFile(fs, "teams/team1/repo1.yaml")
+		assert.Nil(t, err)
+		assert.Contains(t, string(content), "user1")
+		assert.NotContains(t, string(content), "user2")
+	})
+
+	t.Run("happy path: remove deleted external user from bypass_pullrequest_users", func(t *testing.T) {
+		fs := memfs.New()
+		users := make(map[string]*User)
+		externalUsers := make(map[string]*User)
+		// externaluser1 exists, externaluser2 doesn't
+		externalUser1 := &User{}
+		externalUser1.Name = "externaluser1"
+		externalUser1.Spec.GithubID = "externalgithub1"
+		externalUsers["externaluser1"] = externalUser1
+
+		fs.MkdirAll("teams/team1", 0755)
+		err := utils.WriteFile(fs, "teams/team1/repo1.yaml", []byte(`
+apiVersion: v1
+kind: Repository
+name: repo1
+spec:
+  branch_protections:
+    - pattern: main
+      bypass_pullrequest_users:
+        - externaluser1
+        - externaluser2
+`), 0644)
+		assert.Nil(t, err)
+
+		changed, err := ReadAndAdjustRepositories(fs, "archived", "teams", users, externalUsers)
+		assert.Nil(t, err)
+		assert.Equal(t, 1, len(changed))
+
+		// Verify the file was updated
+		content, err := utils.ReadFile(fs, "teams/team1/repo1.yaml")
+		assert.Nil(t, err)
+		assert.Contains(t, string(content), "externaluser1")
+		assert.NotContains(t, string(content), "externaluser2")
+	})
+
+	t.Run("happy path: archived repository with deleted user", func(t *testing.T) {
+		fs := memfs.New()
+		users := make(map[string]*User)
+		user1 := &User{}
+		user1.Name = "user1"
+		user1.Spec.GithubID = "github1"
+		users["user1"] = user1
+
+		fs.MkdirAll("archived", 0755)
+		err := utils.WriteFile(fs, "archived/repo1.yaml", []byte(`
+apiVersion: v1
+kind: Repository
+name: repo1
+spec:
+  branch_protections:
+    - pattern: main
+      bypass_pullrequest_users:
+        - user1
+        - user2
+`), 0644)
+		assert.Nil(t, err)
+
+		changed, err := ReadAndAdjustRepositories(fs, "archived", "teams", users, map[string]*User{})
+		assert.Nil(t, err)
+		assert.Equal(t, 1, len(changed))
+
+		// Verify the file was updated
+		content, err := utils.ReadFile(fs, "archived/repo1.yaml")
+		assert.Nil(t, err)
+		assert.Contains(t, string(content), "user1")
+		assert.NotContains(t, string(content), "user2")
 	})
 }

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -158,6 +158,13 @@ func NewGitHubClientImpl(githubServer, organizationName string, appID int64, pri
 	return client, nil
 }
 
+// getHeaderCaseInsensitive retrieves a header value case-insensitively
+func getHeaderCaseInsensitive(headers http.Header, key string) string {
+	// http.Header.Get() is case-insensitive, but we normalize the key for consistency
+	canonicalKey := http.CanonicalHeaderKey(key)
+	return headers.Get(canonicalKey)
+}
+
 // waitRateLimit helps dealing with rate limits
 // cf https://docs.github.com/en/rest/guides/best-practices-for-integrators?apiVersion=2022-11-28#dealing-with-rate-limits
 func waitRateLimit(resetTimeStr string) error {
@@ -273,21 +280,21 @@ func (client *GitHubClientImpl) QueryGraphQLAPI(ctx context.Context, query strin
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusTooManyRequests || (resp.StatusCode == http.StatusForbidden && resp.Header.Get("X-Ratelimit-Remaining") == "0") {
+	if resp.StatusCode == http.StatusTooManyRequests || (resp.StatusCode == http.StatusForbidden && getHeaderCaseInsensitive(resp.Header, "X-Ratelimit-Remaining") == "0") {
 		if stats != nil {
 			goliacStats := stats.(*config.GoliacStatistics)
 			goliacStats.GithubThrottled++
 		}
 
-		if resp.Header.Get("X-RateLimit-Reset") != "" {
+		if getHeaderCaseInsensitive(resp.Header, "X-RateLimit-Reset") != "" {
 			// We're being rate limited. Get the reset time from the headers.
-			if err := waitRateLimit(resp.Header.Get("X-RateLimit-Reset")); err != nil {
+			if err := waitRateLimit(getHeaderCaseInsensitive(resp.Header, "X-RateLimit-Reset")); err != nil {
 				if childSpan != nil {
 					childSpan.SetStatus(codes.Error, fmt.Sprintf("waitRateLimit: %s", err.Error()))
 				}
 				return nil, err
 			}
-		} else if resp.Header.Get("Retry-After") != "" {
+		} else if getHeaderCaseInsensitive(resp.Header, "Retry-After") != "" {
 			retryAfter, err := strconv.Atoi(resp.Header.Get("Retry-After"))
 			if err != nil {
 				if childSpan != nil {
@@ -418,7 +425,7 @@ func (client *GitHubClientImpl) CallRestAPI(ctx context.Context, endpoint, param
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusTooManyRequests || (resp.StatusCode == http.StatusForbidden && resp.Header.Get("X-Ratelimit-Remaining") == "0") {
+	if resp.StatusCode == http.StatusTooManyRequests || (resp.StatusCode == http.StatusForbidden && getHeaderCaseInsensitive(resp.Header, "X-Ratelimit-Remaining") == "0") {
 		if stats != nil {
 			goliacStats := stats.(*config.GoliacStatistics)
 			goliacStats.GithubThrottled++

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -295,7 +295,7 @@ func (client *GitHubClientImpl) QueryGraphQLAPI(ctx context.Context, query strin
 				return nil, err
 			}
 		} else if getHeaderCaseInsensitive(resp.Header, "Retry-After") != "" {
-			retryAfter, err := strconv.Atoi(resp.Header.Get("Retry-After"))
+			retryAfter, err := strconv.Atoi(getHeaderCaseInsensitive(resp.Header, "Retry-After"))
 			if err != nil {
 				if childSpan != nil {
 					childSpan.SetStatus(codes.Error, fmt.Sprintf("error parsing Retry-After header: %s", err.Error()))
@@ -432,7 +432,7 @@ func (client *GitHubClientImpl) CallRestAPI(ctx context.Context, endpoint, param
 		}
 
 		// We're being rate limited. Get the reset time from the headers.
-		if err := waitRateLimit(resp.Header.Get("X-RateLimit-Reset")); err != nil {
+		if err := waitRateLimit(getHeaderCaseInsensitive(resp.Header, "X-RateLimit-Reset")); err != nil {
 			if childSpan != nil {
 				childSpan.SetStatus(codes.Error, fmt.Sprintf("waitRateLimit: %s", err.Error()))
 			}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -116,3 +116,23 @@ func TestCallRestAPI(t *testing.T) {
 		}
 	})
 }
+
+func TestGetHeaderCaseInsensitive(t *testing.T) {
+	headers := http.Header{
+		"X-Ratelimit-Reset":     {"1763908461"},
+		"Retry-After":           {"30"},
+		"X-Ratelimit-Remaining": {"0"},
+	}
+	header := getHeaderCaseInsensitive(headers, "X-RateLimit-Reset")
+	if header != "1763908461" {
+		t.Errorf("expected '1763908461', got %s", header)
+	}
+	header = getHeaderCaseInsensitive(headers, "Retry-After")
+	if header != "30" {
+		t.Errorf("expected '30', got %s", header)
+	}
+	header = getHeaderCaseInsensitive(headers, "X-RateLimit-Remaining")
+	if header != "0" {
+		t.Errorf("expected '0', got %s", header)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds validation and auto-adjustment for branch protection bypass users, integrates repo changes into user/team sync, and makes GitHub rate-limit header handling case-insensitive.
> 
> - **Repositories/Entity**:
>   - Validate `branch_protections.bypass_pullrequest_users` against `users` and `externalUsers` in `Validate`.
>   - Add `ReadAndAdjustRepositories` (and recursive helper) to remove non-existent users from `bypass_pullrequest_users` and persist updates; expose `Repository.Update`.
>   - Update `ReadRepositories`/helpers to accept `users` and pass to validation.
> - **Engine**:
>   - During `SyncUsersAndTeams`, call `ReadAndAdjustRepositories`; include repo changes in `MaxChangesets` check and commit, and log accordingly.
>   - In `LoadAndValidateLocal`, pass `users` to `ReadRepositories`.
> - **GitHub Client**:
>   - Introduce case-insensitive header access for rate limit handling and use it in GraphQL/REST paths.
> - **Tests**:
>   - Update tests for new `ReadRepositories` signature; add tests for bypass user validation and repository auto-adjustment; add header case-insensitive test.
> - **Changelog**:
>   - Document v1.6.1: rate limit header case fix and bypass user validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 472bfa5ad590abaa551b907c2d0cd61d96103eb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->