### PR TITLE
V1 6 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Goliac v1.6.2
+
+- add support for merge queue in branch protections ruleset
+- add also support for allowed_merge_methods in pull request ruleset
+
 ## Goliac v1.6.1
 
 - bugfix: fix Github rate limiting headers case

--- a/docs/resource_repository.md
+++ b/docs/resource_repository.md
@@ -107,7 +107,7 @@ You can archive a repository, by a PR that move the yaml repository file into th
 ## Adding repository ruleset
 
 You can add different rules on a specific repository (like branch protection) using the new Github rulesets.
-Few rules are currently supported (but the software can be easily extended): `pull_request`, `required_signatures`, `required_status_checks`, `creation`, `update`, `deletion`, `non_fast_forward`, `required_linear_history`
+Few rules are currently supported (but the software can be easily extended): `pull_request`, `required_signatures`, `required_status_checks`, `creation`, `update`, `deletion`, `non_fast_forward`, `required_linear_history`, `merge_queue`
 
 Note: team or app bypass is not supported yet
 
@@ -145,9 +145,13 @@ spec:
           - develop
       rules:
         - ruletype: pull_request
-          parameters: # dismissStaleReviewsOnPush, requireCodeOwnerReview, requiredApprovingReviewCount, requiredReviewThreadResolution, requireLastPushApproval
+          parameters: # dismissStaleReviewsOnPush, requireCodeOwnerReview, requiredApprovingReviewCount, requiredReviewThreadResolution, requireLastPushApproval, allowedMergeMethods
             requiredApprovingReviewCount: 1
             requireLastPushApproval: true
+            allowedMergeMethods:
+              - MERGE
+              - SQUASH
+              - REBASE
             ...
 ```
 
@@ -171,6 +175,33 @@ spec:
           parameters: # requiredStatusChecks, strictRequiredStatusChecksPolicy
             requiredStatusChecks:
               - my_check
+```
+
+`merge_queue` example
+
+```yaml
+apiVersion: v1
+kind: Repository
+name: awesome-repository
+spec:
+  visibility: public
+  ...
+  rulesets:
+    - name: myruleset
+      enforcement: active # disabled, active, evaluate
+      conditions:
+        include:
+          - "~DEFAULT_BRANCH"
+      rules:
+        - ruletype: merge_queue
+          parameters: # checkResponseTimeoutMinutes, groupingStrategy, maxEntriesToBuild, maxEntriesToMerge, mergeMethod, minEntriesToMerge, minEntriesToMergeWaitMinutes
+            checkResponseTimeoutMinutes: 5
+            groupingStrategy: ALLGREEN # ALLGREEN or HEADGREEN
+            maxEntriesToBuild: 10
+            maxEntriesToMerge: 5
+            mergeMethod: MERGE # MERGE, REBASE, or SQUASH
+            minEntriesToMerge: 2
+            minEntriesToMergeWaitMinutes: 5
 ```
 
 ## Adding repository branch protection

--- a/internal/engine/remote_ruleset_test.go
+++ b/internal/engine/remote_ruleset_test.go
@@ -141,18 +141,27 @@ func TestFromGraphQLToGithubRuleset(t *testing.T) {
 							RequiredApprovingReviewCount     int
 							RequiredReviewThreadResolution   bool
 							RequireLastPushApproval          bool
+							AllowedMergeMethods              []string
 							RequiredStatusChecks             []GithubRuleSetRuleStatusCheck
 							StrictRequiredStatusChecksPolicy bool
 							Name                             string
 							Negate                           bool
 							Operator                         string
 							Pattern                          string
+							CheckResponseTimeoutMinutes      int
+							GroupingStrategy                 string
+							MaxEntriesToBuild                int
+							MaxEntriesToMerge                int
+							MergeMethod                      string
+							MinEntriesToMerge                int
+							MinEntriesToMergeWaitMinutes     int
 						}{
 							DismissStaleReviewsOnPush:      true,
 							RequireCodeOwnerReview:         true,
 							RequiredApprovingReviewCount:   2,
 							RequiredReviewThreadResolution: true,
 							RequireLastPushApproval:        true,
+							AllowedMergeMethods:            []string{"MERGE", "SQUASH"},
 						},
 						Type: "PULL_REQUEST",
 					},
@@ -163,12 +172,20 @@ func TestFromGraphQLToGithubRuleset(t *testing.T) {
 							RequiredApprovingReviewCount     int
 							RequiredReviewThreadResolution   bool
 							RequireLastPushApproval          bool
+							AllowedMergeMethods              []string
 							RequiredStatusChecks             []GithubRuleSetRuleStatusCheck
 							StrictRequiredStatusChecksPolicy bool
 							Name                             string
 							Negate                           bool
 							Operator                         string
 							Pattern                          string
+							CheckResponseTimeoutMinutes      int
+							GroupingStrategy                 string
+							MaxEntriesToBuild                int
+							MaxEntriesToMerge                int
+							MergeMethod                      string
+							MinEntriesToMerge                int
+							MinEntriesToMergeWaitMinutes     int
 						}{
 							RequiredStatusChecks: []GithubRuleSetRuleStatusCheck{
 								{Context: "test-check"},
@@ -216,6 +233,7 @@ func TestFromGraphQLToGithubRuleset(t *testing.T) {
 		assert.Equal(t, 2, pullRequestRule.RequiredApprovingReviewCount)
 		assert.True(t, pullRequestRule.RequiredReviewThreadResolution)
 		assert.True(t, pullRequestRule.RequireLastPushApproval)
+		assert.Equal(t, []string{"MERGE", "SQUASH"}, pullRequestRule.AllowedMergeMethods)
 
 		statusChecksRule := result.Rules["required_status_checks"]
 		assert.Equal(t, []string{"test-check"}, statusChecksRule.RequiredStatusChecks)
@@ -827,6 +845,7 @@ func TestUpdateRuleset(t *testing.T) {
 					RequiredApprovingReviewCount:   2,
 					RequiredReviewThreadResolution: true,
 					RequireLastPushApproval:        true,
+					AllowedMergeMethods:            []string{"MERGE", "SQUASH"},
 				},
 				"required_status_checks": {
 					RequiredStatusChecks:             []string{"test-check"},
@@ -918,6 +937,7 @@ func TestUpdateRuleset(t *testing.T) {
 						"required_approving_review_count":   2,
 						"required_review_thread_resolution": true,
 						"require_last_push_approval":        true,
+						"allowed_merge_methods":             []string{"MERGE", "SQUASH"},
 					},
 				},
 				{

--- a/internal/entity/repository.go
+++ b/internal/entity/repository.go
@@ -121,6 +121,26 @@ func NewRepository(fs billy.Filesystem, filename string) (*Repository, error) {
 		repository.Spec.CustomProperties = normalized
 	}
 
+	// set default values for ruleset rules
+	for i, ruleset := range repository.Spec.Rulesets {
+		for j, rule := range ruleset.RuleSetDefinition.Rules {
+			if rule.Ruletype == "pull_request" {
+				if len(rule.Parameters.AllowedMergeMethods) == 0 {
+					// default to MERGE, SQUASH, REBASE
+					rule.Parameters.AllowedMergeMethods = []string{"MERGE", "SQUASH", "REBASE"}
+					ruleset.RuleSetDefinition.Rules[j] = rule
+				}
+			}
+			if rule.Ruletype == "merge_queue" {
+				if rule.Parameters.CheckResponseTimeoutMinutes == 0 {
+					// default to 10 minutes
+					rule.Parameters.CheckResponseTimeoutMinutes = 10
+					ruleset.RuleSetDefinition.Rules[j] = rule
+				}
+			}
+		}
+		repository.Spec.Rulesets[i] = ruleset
+	}
 	return repository, nil
 }
 

--- a/internal/goliac_test.go
+++ b/internal/goliac_test.go
@@ -571,6 +571,7 @@ func (e *GoliacRemoteExecutorMock) RuleSets(ctx context.Context) map[string]*eng
 			Rules: map[string]entity.RuleSetParameters{
 				"pull_request": {
 					RequiredApprovingReviewCount: 1,
+					AllowedMergeMethods:          []string{"MERGE", "SQUASH", "REBASE"},
 				},
 			},
 			Repositories: []string{"repo1", "repo2", "src"},


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add merge queue ruleset support and allowed merge methods for pull_request rules with GraphQL integration, validation/defaults, docs, and tests.
> 
> - **Rulesets/Engine**:
>   - GraphQL: fetch `allowedMergeMethods` for `pull_request` and full `MergeQueueParameters` in `internal/engine/remote.go`.
>   - Data models: extend `GithubRuleSetRule` and entity `RuleSetParameters` with `allowedMergeMethods` and merge queue fields.
>   - Conversion/serialization: propagate fields in `fromGraphQLToGithubRuleset` and include in REST payload via `prepareRuleset` (emit `merge_queue` and `allowed_merge_methods`).
>   - Defaults: set `allowedMergeMethods` (MERGE, SQUASH, REBASE) and `checkResponseTimeoutMinutes` (10) when missing in `internal/entity/entity_ruleset.go` and `internal/entity/repository.go`.
>   - Validation/compare: validate `merge_queue` params and non-empty `allowedMergeMethods`; update `CompareRulesetParameters`.
> - **Docs**:
>   - Update `docs/resource_repository.md` with `merge_queue` support and examples; include `allowedMergeMethods` in `pull_request` example.
>   - Update `CHANGELOG.md` for v1.6.2.
> - **Tests**:
>   - Extend ruleset tests to assert `allowedMergeMethods` handling and payloads; update fixtures in `internal/goliac_test.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f33f9c61f3027213aa67a6ae78ac5058bb878277. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->