### PR TITLE
V1 6 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Goliac v1.6.3
+
+- bugfix: set default values for ruleset rules
+
 ## Goliac v1.6.2
 
 - add support for merge queue in branch protections ruleset

--- a/internal/entity/entity_ruleset.go
+++ b/internal/entity/entity_ruleset.go
@@ -301,8 +301,11 @@ func ValidateRulesetDefinition(r *RuleSetDefinition, filename string) error {
 			if rule.Parameters.CheckResponseTimeoutMinutes == 0 {
 				return fmt.Errorf("invalid ruletype: %s for ruleset filename %s: checkResponseTimeoutMinutes must not be empty ", rule.Ruletype, filename)
 			}
-			if rule.Parameters.GroupingStrategy != "ALLGREEN" && rule.Parameters.GroupingStrategy != "HEADGREEN" {
+			if rule.Parameters.GroupingStrategy != "" && rule.Parameters.GroupingStrategy != "ALLGREEN" && rule.Parameters.GroupingStrategy != "HEADGREEN" {
 				return fmt.Errorf("invalid ruletype: %s for ruleset filename %s: groupingStrategy must be 'ALLGREEN' or 'HEADGREEN' ", rule.Ruletype, filename)
+			}
+			if rule.Parameters.MergeMethod != "" && rule.Parameters.MergeMethod != "MERGE" && rule.Parameters.MergeMethod != "REBASE" && rule.Parameters.MergeMethod != "SQUASH" {
+				return fmt.Errorf("invalid ruletype: %s for ruleset filename %s: mergeMethod must be 'MERGE', 'REBASE' or 'SQUASH' ", rule.Ruletype, filename)
 			}
 		}
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Set sensible defaults for ruleset parameters and relax merge queue validation for optional fields.
> 
> - **Ruleset handling (`internal/entity/entity_ruleset.go`)**:
>   - **Defaults**:
>     - `pull_request`: default `allowedMergeMethods` to `['MERGE','SQUASH','REBASE']` when unset.
>     - `merge_queue`: default `checkResponseTimeoutMinutes` to `10` when unset.
>   - **Validation tweaks**:
>     - `merge_queue`: make `groupingStrategy` optional; if set, only `ALLGREEN` or `HEADGREEN` allowed.
>     - `merge_queue`: validate `mergeMethod` only if set; allowed `MERGE`, `REBASE`, `SQUASH`.
> - **Docs**:
>   - Update `CHANGELOG.md` for v1.6.3 noting default values bugfix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca1ec19514d20d8bcd6846f5024605fc5ac99d8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->