### PR TITLE
V1 6 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Goliac v1.6.5
+
+- add only non-archived repositories to the organization ruleset
+
 ## Goliac v1.6.4
 
 - bugfix: validate mergeMethod compatibility with repository merge settings

--- a/internal/engine/goliac_reconciliator_datasource.go
+++ b/internal/engine/goliac_reconciliator_datasource.go
@@ -397,7 +397,17 @@ func (d *GoliacReconciliatorDatasourceLocal) RuleSets() (map[string]*GithubRuleS
 		if err != nil {
 			return nil, fmt.Errorf("not able to parse ruleset regular expression %s: %v", confrs, err)
 		}
-		grs.Repositories = includedRepositories
+		// Filter out archived repositories
+		nonArchivedRepositories := []string{}
+		for _, reponame := range includedRepositories {
+			if repo, ok := repositories[reponame]; ok {
+				if repo.Archived {
+					continue
+				}
+			}
+			nonArchivedRepositories = append(nonArchivedRepositories, reponame)
+		}
+		grs.Repositories = nonArchivedRepositories
 
 		lgrs[rs.Name] = &grs
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Organization rulesets now include only non-archived repositories; changelog updated to v1.6.5.
> 
> - **Engine**
>   - **Rulesets**: In `internal/engine/goliac_reconciliator_datasource.go`, `RuleSets()` filters out archived repositories when building `grs.Repositories`.
> - **Docs**
>   - Update `CHANGELOG.md` for v1.6.5 noting non-archived repositories inclusion in organization rulesets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae9bde9adcd27c05a9b5b13a67270581270570dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->