### PR TITLE
V1 6 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Goliac v1.6.6
+
+- bugfix: lowercase allowed_merge_methods for merge settings
+
 ## Goliac v1.6.5
 
 - add only non-archived repositories to the organization ruleset

--- a/internal/engine/remote.go
+++ b/internal/engine/remote.go
@@ -2612,7 +2612,11 @@ func (g *GoliacRemoteImpl) prepareRuleset(ruleset *GithubRuleSet) map[string]int
 				"require_last_push_approval":        rule.RequireLastPushApproval,
 			}
 			if len(rule.AllowedMergeMethods) > 0 {
-				params["allowed_merge_methods"] = rule.AllowedMergeMethods
+				mergeMethodsLower := make([]string, len(rule.AllowedMergeMethods))
+				for i, m := range rule.AllowedMergeMethods {
+					mergeMethodsLower[i] = strings.ToLower(m)
+				}
+				params["allowed_merge_methods"] = mergeMethodsLower
 			}
 			rules = append(rules, map[string]interface{}{
 				"type":       "pull_request",

--- a/internal/engine/remote_ruleset_test.go
+++ b/internal/engine/remote_ruleset_test.go
@@ -937,7 +937,7 @@ func TestUpdateRuleset(t *testing.T) {
 						"required_approving_review_count":   2,
 						"required_review_thread_resolution": true,
 						"require_last_push_approval":        true,
-						"allowed_merge_methods":             []string{"MERGE", "SQUASH"},
+						"allowed_merge_methods":             []string{"merge", "squash"},
 					},
 				},
 				{


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Lowercases `allowed_merge_methods` in PR ruleset parameters, updates tests accordingly, and adds v1.6.6 changelog entry.
> 
> - **Engine**:
>   - Normalize `allowed_merge_methods` to lowercase when preparing `pull_request` ruleset parameters in `internal/engine/remote.go`.
> - **Tests**:
>   - Update expectations in `internal/engine/remote_ruleset_test.go` to use lowercase `allowed_merge_methods`.
> - **Changelog**:
>   - Add v1.6.6 entry noting the bugfix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af2a98e98afb73782c00b875fcedb2d4588adaf4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->