### PR TITLE
V1.6.9

### DIFF
--- a/internal/engine/remote.go
+++ b/internal/engine/remote.go
@@ -1105,7 +1105,9 @@ func (g *GoliacRemoteImpl) loadRepositories(ctx context.Context, githubToken *st
 		customPropsPerRepo, err := g.loadCustomPropertiesConcurrently(ctx, config.Config.GithubConcurrentThreads, repositories)
 		if err != nil {
 			logrus.Warnf("error loading custom properties: %v", err)
-			retErr = fmt.Errorf("error loading repository custom properties: %w", err)
+			if retErr == nil {
+				retErr = fmt.Errorf("error loading repository custom properties: %w", err)
+			}
 		} else {
 			for reponame, customProps := range customPropsPerRepo {
 				if repo, ok := repositories[reponame]; ok {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to error aggregation logic during repository loading; behavior only changes in multi-error scenarios.
> 
> **Overview**
> Adjusts repository loading error handling so a failure while fetching org custom properties no longer overwrites a previously captured `retErr` from earlier GraphQL repository pagination/errors; it now only sets `retErr` if it was still `nil`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9761a13036c1fc37e50d5d6743353d188392225. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->