### PR TITLE
V1.6.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Goliac v1.6.10
+
+- bugfix: dont panic on nil ruleset
+
+## Goliac v1.6.9
+
+- bugfix: treat custom properties load failure as loadRepositories failure
+
+## Goliac v1.6.8
+
+- bugfix: treat custom properties load failure as loadRepositories failure
+
 ## Goliac v1.6.7
 
 - couple of security updates

--- a/internal/engine/remote.go
+++ b/internal/engine/remote.go
@@ -2830,6 +2830,9 @@ func (g *GoliacRemoteImpl) AddRepositoryRuleset(ctx context.Context, logsCollect
 	repo = g.repositories[reponame]
 
 	if repo != nil {
+		if repo.RuleSets == nil {
+			repo.RuleSets = make(map[string]*GithubRuleSet)
+		}
 		repo.RuleSets[ruleset.Name] = ruleset
 	}
 }
@@ -2879,6 +2882,9 @@ func (g *GoliacRemoteImpl) UpdateRepositoryRuleset(ctx context.Context, logsColl
 
 	repo = g.repositories[reponame]
 	if repo != nil {
+		if repo.RuleSets == nil {
+			repo.RuleSets = make(map[string]*GithubRuleSet)
+		}
 		repo.RuleSets[ruleset.Name] = ruleset
 	}
 }
@@ -3784,13 +3790,14 @@ func (g *GoliacRemoteImpl) CreateRepository(ctx context.Context, logsCollector *
 
 	// update the repositories list
 	newRepo := &GithubRepository{
-		Name:              reponame,
-		Id:                repoId,
-		RefId:             repoRefId,
-		Visibility:        visibility,
-		BoolProperties:    boolProperties,
-		DefaultBranchName: defaultBranch,
-		IsFork:            forkFrom != "",
+		Name:                reponame,
+		Id:                  repoId,
+		RefId:               repoRefId,
+		Visibility:          visibility,
+		BoolProperties:      boolProperties,
+		DefaultBranchName:   defaultBranch,
+		IsFork:              forkFrom != "",
+		RuleSets:            make(map[string]*GithubRuleSet),
 	}
 	g.repositories[reponame] = newRepo
 	g.repositoriesByRefId[repoRefId] = newRepo


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk bugfix that only initializes `RuleSets` maps before writes to prevent nil-map panics; behavior change is limited to in-memory cache updates after ruleset/repo operations.
> 
> **Overview**
> **Prevents a nil-map panic when creating/updating repository rulesets.** `AddRepositoryRuleset` and `UpdateRepositoryRuleset` now defensively initialize `repo.RuleSets` before assigning to it.
> 
> **Ensures newly created repositories always have a ruleset map.** `CreateRepository` now initializes `RuleSets` on the in-memory `GithubRepository` cache entry.
> 
> Updates `CHANGELOG.md` with the `v1.6.10` bugfix entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ba42a2074e63355293cef58b74b4813c7a1147d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->