### PR TITLE
V1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## Goliac v1.7.0
+
+- add codeowner support
+
+## Goliac v1.6.10
+
+- fix panic: assignment to entry in nil map
+
+## Goliac v1.6.9
+
+- bugfix: improving custom properties load failure as loadRepositories failure
+
+## Goliac v1.6.8
+
+- bugfix: treat custom properties load failure as loadRepositories failure
+
 ## Goliac v1.6.7
 
 - couple of security updates

--- a/docs/resource_repository.md
+++ b/docs/resource_repository.md
@@ -373,6 +373,90 @@ spec:
 
 Topics are displayed on the repository page on GitHub and can be used for searching and filtering repositories.
 
+## CODEOWNERS
+
+Goliac can manage the `.github/CODEOWNERS` file of a repository. This enables per-directory PR approval requirements when combined with rulesets or branch protections that require code owner reviews.
+
+Two modes are available and can be combined:
+
+### Structured CODEOWNERS (validated)
+
+Use `codeowners` for entries where Goliac validates that referenced teams exist. Team names are automatically resolved to `@org/team-slug` format.
+
+```yaml
+apiVersion: v1
+kind: Repository
+name: my-infrastructure
+spec:
+  codeowners:
+    - pattern: "*"
+      owners:
+        - sre-team
+    - pattern: "ac-live-data/"
+      owners:
+        - data-team
+    - pattern: "ac-live-labs/"
+      owners:
+        - labs-team
+        - ml-team
+```
+
+This generates a `.github/CODEOWNERS` file like:
+
+```
+# DO NOT MODIFY THIS FILE MANUALLY
+# This file is managed by Goliac
+
+* @myorg/sre-team
+ac-live-data/ @myorg/data-team
+ac-live-labs/ @myorg/labs-team @myorg/ml-team
+```
+
+Owners can be:
+- **Team names**: resolved to `@org/team-slug` (validated by `goliac verify`)
+- **GitHub usernames**: prefixed with `@` (e.g., `@some-user`), not validated
+
+### Raw CODEOWNERS (unvalidated)
+
+Use `codeowners_raw` when you need full control over the CODEOWNERS content. This content is injected verbatim with no validation of team names or patterns.
+
+```yaml
+apiVersion: v1
+kind: Repository
+name: my-infrastructure
+spec:
+  codeowners_raw: |
+    * @AlayaCare/team-badwolf @AlayaCare/ops-deployment-readonly
+    ac-live-data/ @AlayaCare/team-sphinx
+    ac-live-labs/ @AlayaCare/team-labs
+```
+
+This is useful for:
+- Migrating an existing CODEOWNERS file into Goliac management
+- Referencing external users or teams not managed by Goliac
+- Complex patterns that don't map to Goliac team structures
+
+### Hybrid (both structured and raw)
+
+You can combine both modes. Structured entries appear first (validated), followed by raw entries (unvalidated). This gives you the best of both worlds: validation where possible, flexibility where needed.
+
+```yaml
+apiVersion: v1
+kind: Repository
+name: my-infrastructure
+spec:
+  codeowners:
+    - pattern: "*"
+      owners:
+        - sre-team
+    - pattern: "ac-live-data/"
+      owners:
+        - data-team
+  codeowners_raw: |
+    /vendor/ @external-contributor
+    /legacy/ @AlayaCare/legacy-support
+```
+
 ## Custom properties
 
 You can set custom properties in the repository definition. Custom properties can be strings or arrays of strings.

--- a/internal/engine/goliac_reconciliator.go
+++ b/internal/engine/goliac_reconciliator.go
@@ -351,6 +351,8 @@ type GithubRepoComparable struct {
 	DefaultSquashCommitMessage string
 	CustomProperties           map[string]interface{} // [propertyName]propertyValue (string or []string)
 	Topics                     []string               // repository topics
+	Codeowners                 string                 // generated CODEOWNERS file content
+	CodeownersSHA              string                 // SHA of existing CODEOWNERS file (for updates)
 	// not comparable
 	IsFork   bool
 	ForkFrom string
@@ -771,6 +773,11 @@ func (r *GoliacReconciliatorImpl) reconciliateRepositories(
 		// reconcile topics
 		if res, _, _ := entity.StringArrayEquivalent(lRepo.Topics, rRepo.Topics); !res {
 			r.UpdateRepositoryTopics(ctx, logsCollector, dryrun, remote, reponame, lRepo.Topics)
+		}
+
+		// reconcile CODEOWNERS file
+		if lRepo.Codeowners != "" {
+			r.reconciliateCodeowners(ctx, logsCollector, dryrun, remote, reponame, lRepo.Codeowners)
 		}
 	}
 
@@ -1219,6 +1226,24 @@ func (r *GoliacReconciliatorImpl) UpdateRepositoryTopics(ctx context.Context, lo
 	remote.UpdateRepositoryTopics(reponame, topics)
 	if r.executor != nil {
 		r.executor.UpdateRepositoryTopics(ctx, logsCollector, dryrun, reponame, topics)
+	}
+}
+func (r *GoliacReconciliatorImpl) reconciliateCodeowners(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, remote *MutableGoliacRemoteImpl, reponame string, desiredContent string) {
+	if r.executor == nil {
+		return
+	}
+
+	// Fetch current CODEOWNERS from the repository
+	currentContent, currentSHA, err := r.executor.GetRepositoryCodeowners(ctx, reponame)
+	if err != nil {
+		logsCollector.AddError(fmt.Errorf("failed to get CODEOWNERS for repository %s: %v", reponame, err))
+		return
+	}
+
+	// Compare and update if different
+	if currentContent != desiredContent {
+		logsCollector.AddInfo(map[string]interface{}{"dryrun": dryrun, "command": "update_repository_codeowners"}, "repositoryname: %s", reponame)
+		r.executor.UpdateRepositoryCodeowners(ctx, logsCollector, dryrun, reponame, desiredContent, currentSHA)
 	}
 }
 func (r *GoliacReconciliatorImpl) AddRuleset(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, ruleset *GithubRuleSet) {

--- a/internal/engine/goliac_reconciliator.go
+++ b/internal/engine/goliac_reconciliator.go
@@ -565,6 +565,10 @@ func (r *GoliacReconciliatorImpl) reconciliateRepositories(
 					CompareEntities(lRepo.Autolinks.GetEntity(), rRepo.Autolinks.GetEntity(), compareAutolinks, onAutolinkAdded, onAutolinkRemoved, onAutolinkChange)
 				}
 			}
+
+			if lRepo.Codeowners != rRepo.Codeowners {
+				return false
+			}
 		}
 
 		//

--- a/internal/engine/goliac_reconciliator_datasource.go
+++ b/internal/engine/goliac_reconciliator_datasource.go
@@ -324,6 +324,9 @@ func (d *GoliacReconciliatorDatasourceLocal) Repositories() (map[string]*GithubR
 			}
 		}
 
+		// Generate CODEOWNERS content if codeowners entries are defined
+		codeownersContent := lRepo.GenerateCodeownersContent(config.Config.GithubAppOrganization)
+
 		lRepos[utils.GithubAnsiString(reponame)] = d.reconciliatorFilter.RepositoryFilter(reponame, &GithubRepoComparable{
 			BoolProperties: map[string]bool{
 				"archived":               lRepo.Archived,
@@ -350,6 +353,7 @@ func (d *GoliacReconciliatorDatasourceLocal) Repositories() (map[string]*GithubR
 			DefaultSquashCommitMessage: lRepo.Spec.DefaultSquashCommitMessage,
 			CustomProperties:           customProps,
 			Topics:                     lRepo.Spec.Topics,
+			Codeowners:                 codeownersContent,
 			IsFork:                     lRepo.ForkFrom != "",
 			ForkFrom:                   lRepo.ForkFrom,
 		})
@@ -515,6 +519,8 @@ func (d *GoliacReconciliatorDatasourceRemote) Repositories() (map[string]*Github
 			DefaultSquashCommitMessage: v.DefaultSquashCommitMessage,
 			CustomProperties:           make(map[string]interface{}),
 			Topics:                     v.Topics,
+			Codeowners:                 v.CodeownersContent,
+			CodeownersSHA:              v.CodeownersSHA,
 			IsFork:                     v.IsFork,
 		}
 		for pk, pv := range v.BoolProperties {

--- a/internal/engine/goliac_reconciliator_test.go
+++ b/internal/engine/goliac_reconciliator_test.go
@@ -308,6 +308,12 @@ func (r *ReconciliatorListenerRecorder) UpdateRepositoryCustomProperties(ctx con
 func (r *ReconciliatorListenerRecorder) UpdateRepositoryTopics(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, topics []string) {
 	// Track topics updates if needed for testing
 }
+func (r *ReconciliatorListenerRecorder) GetRepositoryCodeowners(ctx context.Context, reponame string) (string, string, error) {
+	return "", "", nil
+}
+func (r *ReconciliatorListenerRecorder) UpdateRepositoryCodeowners(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, content string, existingSHA string) {
+	// Track CODEOWNERS updates if needed for testing
+}
 func (r *ReconciliatorListenerRecorder) UpdateRepositorySetExternalUser(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, githubid string, permission string) {
 	r.RepositoriesSetExternalUser[githubid] = permission
 }

--- a/internal/engine/reconciliator_executor.go
+++ b/internal/engine/reconciliator_executor.go
@@ -60,6 +60,10 @@ type ReconciliatorExecutor interface {
 	DeleteRepositoryAutolink(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, repositoryName string, autolinkId int)
 	UpdateRepositoryAutolink(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, repositoryName string, previousAutolinkId int, autolink *GithubAutolink)
 
+	// Repository CODEOWNERS file management
+	GetRepositoryCodeowners(ctx context.Context, reponame string) (content string, sha string, err error)
+	UpdateRepositoryCodeowners(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, content string, existingSHA string)
+
 	// Organization custom properties management
 	CreateOrUpdateOrgCustomProperty(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, property *config.GithubCustomProperty)
 	DeleteOrgCustomProperty(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, propertyName string)

--- a/internal/engine/remote.go
+++ b/internal/engine/remote.go
@@ -87,6 +87,8 @@ type GithubRepository struct {
 	DefaultSquashCommitMessage string
 	CustomProperties           map[string]interface{} // [propertyName]propertyValue (string or []string)
 	Topics                     []string               // repository topics
+	CodeownersContent          string                 // content of .github/CODEOWNERS file
+	CodeownersSHA              string                 // SHA of .github/CODEOWNERS file (needed for updates)
 }
 
 type GithubUser struct {
@@ -4099,6 +4101,77 @@ func (g *GoliacRemoteImpl) UpdateRepositoryTopics(ctx context.Context, logsColle
 	repo = g.repositories[reponame]
 	if repo != nil {
 		repo.Topics = topics
+	}
+}
+
+// GetRepositoryCodeowners fetches the CODEOWNERS file content and SHA from a repository.
+// Returns content, sha, error. If the file doesn't exist, returns empty strings with no error.
+func (g *GoliacRemoteImpl) GetRepositoryCodeowners(ctx context.Context, reponame string) (string, string, error) {
+	data, err := g.client.CallRestAPI(
+		ctx,
+		fmt.Sprintf("/repos/%s/%s/contents/.github/CODEOWNERS", g.configGithubOrg, reponame),
+		"",
+		"GET",
+		nil,
+		nil,
+	)
+	if err != nil {
+		// File doesn't exist - not an error, just means no CODEOWNERS
+		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "Not Found") {
+			return "", "", nil
+		}
+		return "", "", err
+	}
+
+	var fileResponse struct {
+		Content  string `json:"content"`
+		SHA      string `json:"sha"`
+		Encoding string `json:"encoding"`
+	}
+	if err := json.Unmarshal(data, &fileResponse); err != nil {
+		return "", "", fmt.Errorf("failed to parse CODEOWNERS response for %s: %v", reponame, err)
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(fileResponse.Content, "\n", ""))
+	if err != nil {
+		return "", "", fmt.Errorf("failed to decode CODEOWNERS content for %s: %v", reponame, err)
+	}
+
+	return string(decoded), fileResponse.SHA, nil
+}
+
+func (g *GoliacRemoteImpl) UpdateRepositoryCodeowners(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, content string, existingSHA string) {
+	// https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#create-or-update-file-contents
+	if !dryrun {
+		body := map[string]interface{}{
+			"message": "update CODEOWNERS (managed by Goliac)",
+			"content": base64.StdEncoding.EncodeToString([]byte(content)),
+		}
+		if existingSHA != "" {
+			body["sha"] = existingSHA
+		}
+
+		_, err := g.client.CallRestAPI(
+			ctx,
+			fmt.Sprintf("/repos/%s/%s/contents/.github/CODEOWNERS", g.configGithubOrg, reponame),
+			"",
+			"PUT",
+			body,
+			nil,
+		)
+		if err != nil {
+			logsCollector.AddError(fmt.Errorf("failed to update CODEOWNERS for repository %s: %v", reponame, err))
+			return
+		}
+	}
+
+	// Update local cache
+	g.actionMutex.Lock()
+	defer g.actionMutex.Unlock()
+
+	repo := g.repositories[reponame]
+	if repo != nil {
+		repo.CodeownersContent = content
 	}
 }
 

--- a/internal/engine/remote.go
+++ b/internal/engine/remote.go
@@ -4141,6 +4141,7 @@ func (g *GoliacRemoteImpl) GetRepositoryCodeowners(ctx context.Context, reponame
 }
 
 func (g *GoliacRemoteImpl) UpdateRepositoryCodeowners(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, content string, existingSHA string) {
+	var newSHA string
 	// https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#create-or-update-file-contents
 	if !dryrun {
 		body := map[string]interface{}{
@@ -4151,7 +4152,7 @@ func (g *GoliacRemoteImpl) UpdateRepositoryCodeowners(ctx context.Context, logsC
 			body["sha"] = existingSHA
 		}
 
-		_, err := g.client.CallRestAPI(
+		respBody, err := g.client.CallRestAPI(
 			ctx,
 			fmt.Sprintf("/repos/%s/%s/contents/.github/CODEOWNERS", g.configGithubOrg, reponame),
 			"",
@@ -4163,6 +4164,23 @@ func (g *GoliacRemoteImpl) UpdateRepositoryCodeowners(ctx context.Context, logsC
 			logsCollector.AddError(fmt.Errorf("failed to update CODEOWNERS for repository %s: %v", reponame, err))
 			return
 		}
+		var putResp struct {
+			Content struct {
+				SHA string `json:"sha"`
+			} `json:"content"`
+		}
+		if err := json.Unmarshal(respBody, &putResp); err == nil && putResp.Content.SHA != "" {
+			newSHA = putResp.Content.SHA
+		} else {
+			_, sha, errFetch := g.GetRepositoryCodeowners(ctx, reponame)
+			if errFetch != nil {
+				logsCollector.AddError(fmt.Errorf("could not determine new CODEOWNERS SHA for repository %s after update (re-fetch: %v)", reponame, errFetch))
+			} else if sha != "" {
+				newSHA = sha
+			} else {
+				logsCollector.AddError(fmt.Errorf("CODEOWNERS SHA empty for repository %s after update; local cache may be stale", reponame))
+			}
+		}
 	}
 
 	// Update local cache
@@ -4172,6 +4190,9 @@ func (g *GoliacRemoteImpl) UpdateRepositoryCodeowners(ctx context.Context, logsC
 	repo := g.repositories[reponame]
 	if repo != nil {
 		repo.CodeownersContent = content
+		if newSHA != "" {
+			repo.CodeownersSHA = newSHA
+		}
 	}
 }
 

--- a/internal/entity/repository.go
+++ b/internal/entity/repository.go
@@ -13,6 +13,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+type RepositoryCodeownersEntry struct {
+	Pattern string   `yaml:"pattern"`
+	Owners  []string `yaml:"owners"` // team names (resolved to @org/team-slug) or GitHub usernames (prefixed with @)
+}
+
 type RepositoryEnvironment struct {
 	Name      string            `yaml:"name"`
 	Variables map[string]string `yaml:"variables,omitempty"`
@@ -48,6 +53,7 @@ type Repository struct {
 		Autolinks                  *[]RepositoryAutolink        `yaml:"autolinks,omitempty"`
 		CustomProperties           map[string]interface{}       `yaml:"custom_properties,omitempty"`
 		Topics                     []string                     `yaml:"topics,omitempty"`
+		Codeowners                 []RepositoryCodeownersEntry  `yaml:"codeowners,omitempty"`
 	} `yaml:"spec,omitempty"`
 	Archived      bool    `yaml:"archived,omitempty"` // implicit: will be set by Goliac
 	Owner         *string `yaml:"-"`                  // implicit. team name owning the repo (if any)
@@ -403,6 +409,26 @@ func (r *Repository) Validate(filename string, teams map[string]*Team, externalU
 		}
 	}
 
+	// Validate codeowners entries
+	for i, entry := range r.Spec.Codeowners {
+		if entry.Pattern == "" {
+			return fmt.Errorf("invalid codeowners entry %d: pattern is empty (check repository filename %s)", i, filename)
+		}
+		if len(entry.Owners) == 0 {
+			return fmt.Errorf("invalid codeowners entry %d: owners is empty (check repository filename %s)", i, filename)
+		}
+		for _, owner := range entry.Owners {
+			// owners starting with @ are direct GitHub usernames, skip team validation
+			if strings.HasPrefix(owner, "@") {
+				continue
+			}
+			// otherwise it must be a team name
+			if _, ok := teams[owner]; !ok {
+				return fmt.Errorf("invalid codeowners owner: team %s doesn't exist (check repository filename %s)", owner, filename)
+			}
+		}
+	}
+
 	if r.Spec.CustomProperties != nil {
 		for propName := range r.Spec.CustomProperties {
 			found := false
@@ -419,6 +445,36 @@ func (r *Repository) Validate(filename string, teams map[string]*Team, externalU
 	}
 
 	return nil
+}
+
+// GenerateCodeownersContent generates the CODEOWNERS file content from the repository's
+// codeowners spec entries. It resolves team names to GitHub team mentions (@org/team-slug).
+// Returns empty string if no codeowners entries are defined.
+func (r *Repository) GenerateCodeownersContent(githubOrganization string) string {
+	if len(r.Spec.Codeowners) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString("# DO NOT MODIFY THIS FILE MANUALLY\n")
+	sb.WriteString("# This file is managed by Goliac\n")
+	sb.WriteString("\n")
+
+	for _, entry := range r.Spec.Codeowners {
+		owners := make([]string, 0, len(entry.Owners))
+		for _, owner := range entry.Owners {
+			if strings.HasPrefix(owner, "@") {
+				// Direct GitHub username
+				owners = append(owners, owner)
+			} else {
+				// Team name - resolve to @org/team-slug
+				owners = append(owners, fmt.Sprintf("@%s/%s", githubOrganization, owner))
+			}
+		}
+		sb.WriteString(fmt.Sprintf("%s %s\n", entry.Pattern, strings.Join(owners, " ")))
+	}
+
+	return sb.String()
 }
 
 /**

--- a/internal/entity/repository.go
+++ b/internal/entity/repository.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/go-git/go-billy/v5"
@@ -448,9 +449,26 @@ func (r *Repository) Validate(filename string, teams map[string]*Team, externalU
 	return nil
 }
 
-// GenerateCodeownersContent generates the CODEOWNERS file content from the repository's
-// codeowners spec entries and/or raw content. It resolves team names in structured entries
-// to GitHub team mentions (@org/team-slug). Raw content is included verbatim.
+// codeownersPatternField returns the first field of a CODEOWNERS rule line (the path/pattern).
+// Comment and empty lines yield an empty string.
+func codeownersPatternField(line string) string {
+	line = strings.TrimSpace(line)
+	if line == "" || strings.HasPrefix(line, "#") {
+		return ""
+	}
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
+}
+
+// GenerateCodeownersContent generates the CODEOWNERS file content from structured spec.codeowners
+// and/or codeowners_raw. Team names in structured entries resolve to @org/team-slug.
+// Structured and raw rule lines are merged; comment lines from raw (lines whose trimmed content
+// starts with #) are emitted after the Goliac header and before rule lines. Rule lines are sorted
+// by ascending length of the path/pattern (first field), stable for ties. codeowners_raw rule lines
+// are not validated.
 // Returns empty string if neither codeowners nor codeowners_raw are defined.
 func (r *Repository) GenerateCodeownersContent(githubOrganization string) string {
 	hasStructured := len(r.Spec.Codeowners) > 0
@@ -460,34 +478,57 @@ func (r *Repository) GenerateCodeownersContent(githubOrganization string) string
 		return ""
 	}
 
-	var sb strings.Builder
-	sb.WriteString("# DO NOT MODIFY THIS FILE MANUALLY\n")
-	sb.WriteString("# This file is managed by Goliac\n")
-	sb.WriteString("\n")
+	var ruleLines []string
+	var commentLines []string
 
-	// Structured entries first (validated by goliac verify)
 	if hasStructured {
 		for _, entry := range r.Spec.Codeowners {
 			owners := make([]string, 0, len(entry.Owners))
 			for _, owner := range entry.Owners {
 				if strings.HasPrefix(owner, "@") {
-					// Direct GitHub username or @org/team reference
 					owners = append(owners, owner)
 				} else {
-					// Team name - resolve to @org/team-slug
 					owners = append(owners, fmt.Sprintf("@%s/%s", githubOrganization, owner))
 				}
 			}
-			sb.WriteString(fmt.Sprintf("%s %s\n", entry.Pattern, strings.Join(owners, " ")))
+			ruleLines = append(ruleLines, fmt.Sprintf("%s %s", entry.Pattern, strings.Join(owners, " ")))
 		}
 	}
 
-	// Raw content appended verbatim (no validation)
 	if hasRaw {
-		if hasStructured {
-			sb.WriteString("\n# Raw CODEOWNERS entries (not validated by Goliac)\n")
+		for _, line := range strings.Split(r.Spec.CodeownersRaw, "\n") {
+			line = strings.TrimRight(line, "\r")
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" {
+				continue
+			}
+			if strings.HasPrefix(trimmed, "#") {
+				commentLines = append(commentLines, trimmed)
+			} else {
+				ruleLines = append(ruleLines, trimmed)
+			}
 		}
-		sb.WriteString(strings.TrimSpace(r.Spec.CodeownersRaw))
+	}
+
+	sort.SliceStable(ruleLines, func(i, j int) bool {
+		pi := codeownersPatternField(ruleLines[i])
+		pj := codeownersPatternField(ruleLines[j])
+		return len(pi) < len(pj)
+	})
+
+	var sb strings.Builder
+	sb.WriteString("# DO NOT MODIFY THIS FILE MANUALLY\n")
+	sb.WriteString("# This file is managed by Goliac\n")
+	sb.WriteString("\n")
+	for _, c := range commentLines {
+		sb.WriteString(c)
+		sb.WriteString("\n")
+	}
+	if len(commentLines) > 0 && len(ruleLines) > 0 {
+		sb.WriteString("\n")
+	}
+	for _, line := range ruleLines {
+		sb.WriteString(line)
 		sb.WriteString("\n")
 	}
 

--- a/internal/entity/repository.go
+++ b/internal/entity/repository.go
@@ -54,6 +54,7 @@ type Repository struct {
 		CustomProperties           map[string]interface{}       `yaml:"custom_properties,omitempty"`
 		Topics                     []string                     `yaml:"topics,omitempty"`
 		Codeowners                 []RepositoryCodeownersEntry  `yaml:"codeowners,omitempty"`
+		CodeownersRaw              string                       `yaml:"codeowners_raw,omitempty"`
 	} `yaml:"spec,omitempty"`
 	Archived      bool    `yaml:"archived,omitempty"` // implicit: will be set by Goliac
 	Owner         *string `yaml:"-"`                  // implicit. team name owning the repo (if any)
@@ -448,10 +449,14 @@ func (r *Repository) Validate(filename string, teams map[string]*Team, externalU
 }
 
 // GenerateCodeownersContent generates the CODEOWNERS file content from the repository's
-// codeowners spec entries. It resolves team names to GitHub team mentions (@org/team-slug).
-// Returns empty string if no codeowners entries are defined.
+// codeowners spec entries and/or raw content. It resolves team names in structured entries
+// to GitHub team mentions (@org/team-slug). Raw content is included verbatim.
+// Returns empty string if neither codeowners nor codeowners_raw are defined.
 func (r *Repository) GenerateCodeownersContent(githubOrganization string) string {
-	if len(r.Spec.Codeowners) == 0 {
+	hasStructured := len(r.Spec.Codeowners) > 0
+	hasRaw := strings.TrimSpace(r.Spec.CodeownersRaw) != ""
+
+	if !hasStructured && !hasRaw {
 		return ""
 	}
 
@@ -460,18 +465,30 @@ func (r *Repository) GenerateCodeownersContent(githubOrganization string) string
 	sb.WriteString("# This file is managed by Goliac\n")
 	sb.WriteString("\n")
 
-	for _, entry := range r.Spec.Codeowners {
-		owners := make([]string, 0, len(entry.Owners))
-		for _, owner := range entry.Owners {
-			if strings.HasPrefix(owner, "@") {
-				// Direct GitHub username
-				owners = append(owners, owner)
-			} else {
-				// Team name - resolve to @org/team-slug
-				owners = append(owners, fmt.Sprintf("@%s/%s", githubOrganization, owner))
+	// Structured entries first (validated by goliac verify)
+	if hasStructured {
+		for _, entry := range r.Spec.Codeowners {
+			owners := make([]string, 0, len(entry.Owners))
+			for _, owner := range entry.Owners {
+				if strings.HasPrefix(owner, "@") {
+					// Direct GitHub username or @org/team reference
+					owners = append(owners, owner)
+				} else {
+					// Team name - resolve to @org/team-slug
+					owners = append(owners, fmt.Sprintf("@%s/%s", githubOrganization, owner))
+				}
 			}
+			sb.WriteString(fmt.Sprintf("%s %s\n", entry.Pattern, strings.Join(owners, " ")))
 		}
-		sb.WriteString(fmt.Sprintf("%s %s\n", entry.Pattern, strings.Join(owners, " ")))
+	}
+
+	// Raw content appended verbatim (no validation)
+	if hasRaw {
+		if hasStructured {
+			sb.WriteString("\n# Raw CODEOWNERS entries (not validated by Goliac)\n")
+		}
+		sb.WriteString(strings.TrimSpace(r.Spec.CodeownersRaw))
+		sb.WriteString("\n")
 	}
 
 	return sb.String()

--- a/internal/entity/repository_test.go
+++ b/internal/entity/repository_test.go
@@ -383,7 +383,8 @@ func TestGenerateCodeownersContent(t *testing.T) {
 		repo := &Repository{}
 		repo.Spec.CodeownersRaw = "/vendor/ @external-user\n/docs/ @myorg/docs-team"
 		content := repo.GenerateCodeownersContent("myorg")
-		expected := "# DO NOT MODIFY THIS FILE MANUALLY\n# This file is managed by Goliac\n\n/vendor/ @external-user\n/docs/ @myorg/docs-team\n"
+		// sorted by pattern length: /docs/ (7) < /vendor/ (9)
+		expected := "# DO NOT MODIFY THIS FILE MANUALLY\n# This file is managed by Goliac\n\n/docs/ @myorg/docs-team\n/vendor/ @external-user\n"
 		assert.Equal(t, expected, content)
 	})
 
@@ -395,7 +396,30 @@ func TestGenerateCodeownersContent(t *testing.T) {
 		}
 		repo.Spec.CodeownersRaw = "/vendor/ @external-user"
 		content := repo.GenerateCodeownersContent("myorg")
-		expected := "# DO NOT MODIFY THIS FILE MANUALLY\n# This file is managed by Goliac\n\n* @myorg/sre\nac-live-data/ @myorg/data-team\n\n# Raw CODEOWNERS entries (not validated by Goliac)\n/vendor/ @external-user\n"
+		// merged then sorted: * (1), /vendor/ (9), ac-live-data/ (13)
+		expected := "# DO NOT MODIFY THIS FILE MANUALLY\n# This file is managed by Goliac\n\n* @myorg/sre\n/vendor/ @external-user\nac-live-data/ @myorg/data-team\n"
+		assert.Equal(t, expected, content)
+	})
+
+	t.Run("sorts merged rules by pattern length", func(t *testing.T) {
+		repo := &Repository{}
+		repo.Spec.Codeowners = []RepositoryCodeownersEntry{
+			{Pattern: "/zz/long/", Owners: []string{"a"}},
+		}
+		repo.Spec.CodeownersRaw = "* @x\n/foo/ @y"
+		content := repo.GenerateCodeownersContent("myorg")
+		expected := "# DO NOT MODIFY THIS FILE MANUALLY\n# This file is managed by Goliac\n\n* @x\n/foo/ @y\n/zz/long/ @myorg/a\n"
+		assert.Equal(t, expected, content)
+	})
+
+	t.Run("raw comment lines stay above rules", func(t *testing.T) {
+		repo := &Repository{}
+		repo.Spec.CodeownersRaw = `# not a rule
+# second comment
+/long/path/ @a
+* @b`
+		content := repo.GenerateCodeownersContent("myorg")
+		expected := "# DO NOT MODIFY THIS FILE MANUALLY\n# This file is managed by Goliac\n\n# not a rule\n# second comment\n\n* @b\n/long/path/ @a\n"
 		assert.Equal(t, expected, content)
 	})
 

--- a/internal/entity/repository_test.go
+++ b/internal/entity/repository_test.go
@@ -341,6 +341,163 @@ spec:
 	})
 }
 
+func TestGenerateCodeownersContent(t *testing.T) {
+	t.Run("empty codeowners", func(t *testing.T) {
+		repo := &Repository{}
+		content := repo.GenerateCodeownersContent("myorg")
+		assert.Equal(t, "", content)
+	})
+
+	t.Run("single team owner", func(t *testing.T) {
+		repo := &Repository{}
+		repo.Spec.Codeowners = []RepositoryCodeownersEntry{
+			{Pattern: "*", Owners: []string{"sre"}},
+		}
+		content := repo.GenerateCodeownersContent("myorg")
+		expected := "# DO NOT MODIFY THIS FILE MANUALLY\n# This file is managed by Goliac\n\n* @myorg/sre\n"
+		assert.Equal(t, expected, content)
+	})
+
+	t.Run("multiple entries with teams and users", func(t *testing.T) {
+		repo := &Repository{}
+		repo.Spec.Codeowners = []RepositoryCodeownersEntry{
+			{Pattern: "*", Owners: []string{"sre"}},
+			{Pattern: "/labs/anyscale/", Owners: []string{"labs-team", "@some-user"}},
+		}
+		content := repo.GenerateCodeownersContent("myorg")
+		expected := "# DO NOT MODIFY THIS FILE MANUALLY\n# This file is managed by Goliac\n\n* @myorg/sre\n/labs/anyscale/ @myorg/labs-team @some-user\n"
+		assert.Equal(t, expected, content)
+	})
+
+	t.Run("multiple owners per pattern", func(t *testing.T) {
+		repo := &Repository{}
+		repo.Spec.Codeowners = []RepositoryCodeownersEntry{
+			{Pattern: "*.go", Owners: []string{"backend", "devops"}},
+		}
+		content := repo.GenerateCodeownersContent("myorg")
+		expected := "# DO NOT MODIFY THIS FILE MANUALLY\n# This file is managed by Goliac\n\n*.go @myorg/backend @myorg/devops\n"
+		assert.Equal(t, expected, content)
+	})
+}
+
+func TestRepositoryCodeownersValidation(t *testing.T) {
+	t.Run("happy path: valid codeowners with team reference", func(t *testing.T) {
+		fs := memfs.New()
+		fixtureCreateUserTeam(t, fs)
+
+		err := utils.WriteFile(fs, "teams/team1/repo1.yaml", []byte(`
+apiVersion: v1
+kind: Repository
+name: repo1
+spec:
+  codeowners:
+    - pattern: "*"
+      owners:
+        - team1
+`), 0644)
+		assert.Nil(t, err)
+
+		logsCollector := observability.NewLogCollection()
+		users := ReadUserDirectory(fs, "users", logsCollector)
+		teams := ReadTeamDirectory(fs, "teams", users, logsCollector)
+		repos := ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, users, []*config.GithubCustomProperty{}, logsCollector)
+		assert.False(t, logsCollector.HasErrors())
+		assert.Equal(t, 1, len(repos))
+	})
+
+	t.Run("happy path: codeowners with direct user reference", func(t *testing.T) {
+		fs := memfs.New()
+		fixtureCreateUserTeam(t, fs)
+
+		err := utils.WriteFile(fs, "teams/team1/repo1.yaml", []byte(`
+apiVersion: v1
+kind: Repository
+name: repo1
+spec:
+  codeowners:
+    - pattern: "*"
+      owners:
+        - "@some-github-user"
+`), 0644)
+		assert.Nil(t, err)
+
+		logsCollector := observability.NewLogCollection()
+		users := ReadUserDirectory(fs, "users", logsCollector)
+		teams := ReadTeamDirectory(fs, "teams", users, logsCollector)
+		repos := ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, users, []*config.GithubCustomProperty{}, logsCollector)
+		assert.False(t, logsCollector.HasErrors())
+		assert.Equal(t, 1, len(repos))
+	})
+
+	t.Run("not happy path: codeowners with invalid team", func(t *testing.T) {
+		fs := memfs.New()
+		fixtureCreateUserTeam(t, fs)
+
+		err := utils.WriteFile(fs, "teams/team1/repo1.yaml", []byte(`
+apiVersion: v1
+kind: Repository
+name: repo1
+spec:
+  codeowners:
+    - pattern: "*"
+      owners:
+        - nonexistent-team
+`), 0644)
+		assert.Nil(t, err)
+
+		logsCollector := observability.NewLogCollection()
+		users := ReadUserDirectory(fs, "users", logsCollector)
+		teams := ReadTeamDirectory(fs, "teams", users, logsCollector)
+		ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, users, []*config.GithubCustomProperty{}, logsCollector)
+		assert.True(t, logsCollector.HasErrors())
+	})
+
+	t.Run("not happy path: codeowners with empty pattern", func(t *testing.T) {
+		fs := memfs.New()
+		fixtureCreateUserTeam(t, fs)
+
+		err := utils.WriteFile(fs, "teams/team1/repo1.yaml", []byte(`
+apiVersion: v1
+kind: Repository
+name: repo1
+spec:
+  codeowners:
+    - pattern: ""
+      owners:
+        - team1
+`), 0644)
+		assert.Nil(t, err)
+
+		logsCollector := observability.NewLogCollection()
+		users := ReadUserDirectory(fs, "users", logsCollector)
+		teams := ReadTeamDirectory(fs, "teams", users, logsCollector)
+		ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, users, []*config.GithubCustomProperty{}, logsCollector)
+		assert.True(t, logsCollector.HasErrors())
+	})
+
+	t.Run("not happy path: codeowners with empty owners", func(t *testing.T) {
+		fs := memfs.New()
+		fixtureCreateUserTeam(t, fs)
+
+		err := utils.WriteFile(fs, "teams/team1/repo1.yaml", []byte(`
+apiVersion: v1
+kind: Repository
+name: repo1
+spec:
+  codeowners:
+    - pattern: "*"
+      owners: []
+`), 0644)
+		assert.Nil(t, err)
+
+		logsCollector := observability.NewLogCollection()
+		users := ReadUserDirectory(fs, "users", logsCollector)
+		teams := ReadTeamDirectory(fs, "teams", users, logsCollector)
+		ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, users, []*config.GithubCustomProperty{}, logsCollector)
+		assert.True(t, logsCollector.HasErrors())
+	})
+}
+
 func TestReadAndAdjustRepositories(t *testing.T) {
 	t.Run("happy path: no repositories, no problem", func(t *testing.T) {
 		fs := memfs.New()

--- a/internal/entity/repository_test.go
+++ b/internal/entity/repository_test.go
@@ -378,6 +378,41 @@ func TestGenerateCodeownersContent(t *testing.T) {
 		expected := "# DO NOT MODIFY THIS FILE MANUALLY\n# This file is managed by Goliac\n\n*.go @myorg/backend @myorg/devops\n"
 		assert.Equal(t, expected, content)
 	})
+
+	t.Run("raw only", func(t *testing.T) {
+		repo := &Repository{}
+		repo.Spec.CodeownersRaw = "/vendor/ @external-user\n/docs/ @myorg/docs-team"
+		content := repo.GenerateCodeownersContent("myorg")
+		expected := "# DO NOT MODIFY THIS FILE MANUALLY\n# This file is managed by Goliac\n\n/vendor/ @external-user\n/docs/ @myorg/docs-team\n"
+		assert.Equal(t, expected, content)
+	})
+
+	t.Run("hybrid structured and raw", func(t *testing.T) {
+		repo := &Repository{}
+		repo.Spec.Codeowners = []RepositoryCodeownersEntry{
+			{Pattern: "*", Owners: []string{"sre"}},
+			{Pattern: "ac-live-data/", Owners: []string{"data-team"}},
+		}
+		repo.Spec.CodeownersRaw = "/vendor/ @external-user"
+		content := repo.GenerateCodeownersContent("myorg")
+		expected := "# DO NOT MODIFY THIS FILE MANUALLY\n# This file is managed by Goliac\n\n* @myorg/sre\nac-live-data/ @myorg/data-team\n\n# Raw CODEOWNERS entries (not validated by Goliac)\n/vendor/ @external-user\n"
+		assert.Equal(t, expected, content)
+	})
+
+	t.Run("empty raw whitespace is ignored", func(t *testing.T) {
+		repo := &Repository{}
+		repo.Spec.CodeownersRaw = "   \n  \n  "
+		content := repo.GenerateCodeownersContent("myorg")
+		assert.Equal(t, "", content)
+	})
+
+	t.Run("both empty returns empty", func(t *testing.T) {
+		repo := &Repository{}
+		repo.Spec.Codeowners = []RepositoryCodeownersEntry{}
+		repo.Spec.CodeownersRaw = ""
+		content := repo.GenerateCodeownersContent("myorg")
+		assert.Equal(t, "", content)
+	})
 }
 
 func TestRepositoryCodeownersValidation(t *testing.T) {
@@ -473,6 +508,55 @@ spec:
 		teams := ReadTeamDirectory(fs, "teams", users, logsCollector)
 		ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, users, []*config.GithubCustomProperty{}, logsCollector)
 		assert.True(t, logsCollector.HasErrors())
+	})
+
+	t.Run("happy path: codeowners_raw only", func(t *testing.T) {
+		fs := memfs.New()
+		fixtureCreateUserTeam(t, fs)
+
+		err := utils.WriteFile(fs, "teams/team1/repo1.yaml", []byte(`
+apiVersion: v1
+kind: Repository
+name: repo1
+spec:
+  codeowners_raw: |
+    * @AlayaCare/team-badwolf
+    ac-live-data/ @AlayaCare/team-sphinx
+`), 0644)
+		assert.Nil(t, err)
+
+		logsCollector := observability.NewLogCollection()
+		users := ReadUserDirectory(fs, "users", logsCollector)
+		teams := ReadTeamDirectory(fs, "teams", users, logsCollector)
+		repos := ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, users, []*config.GithubCustomProperty{}, logsCollector)
+		assert.False(t, logsCollector.HasErrors())
+		assert.Equal(t, 1, len(repos))
+	})
+
+	t.Run("happy path: hybrid codeowners and codeowners_raw", func(t *testing.T) {
+		fs := memfs.New()
+		fixtureCreateUserTeam(t, fs)
+
+		err := utils.WriteFile(fs, "teams/team1/repo1.yaml", []byte(`
+apiVersion: v1
+kind: Repository
+name: repo1
+spec:
+  codeowners:
+    - pattern: "*"
+      owners:
+        - team1
+  codeowners_raw: |
+    /vendor/ @external-contributor
+`), 0644)
+		assert.Nil(t, err)
+
+		logsCollector := observability.NewLogCollection()
+		users := ReadUserDirectory(fs, "users", logsCollector)
+		teams := ReadTeamDirectory(fs, "teams", users, logsCollector)
+		repos := ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, users, []*config.GithubCustomProperty{}, logsCollector)
+		assert.False(t, logsCollector.HasErrors())
+		assert.Equal(t, 1, len(repos))
 	})
 
 	t.Run("not happy path: codeowners with empty owners", func(t *testing.T) {

--- a/internal/github_batch_executor.go
+++ b/internal/github_batch_executor.go
@@ -191,6 +191,21 @@ func (g *GithubBatchExecutor) UpdateRepositoryTopics(ctx context.Context, logsCo
 	})
 }
 
+func (g *GithubBatchExecutor) GetRepositoryCodeowners(ctx context.Context, reponame string) (string, string, error) {
+	// GetRepositoryCodeowners is not batched - it's a read operation that must be executed immediately
+	return g.client.GetRepositoryCodeowners(ctx, reponame)
+}
+
+func (g *GithubBatchExecutor) UpdateRepositoryCodeowners(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, content string, existingSHA string) {
+	g.commands = append(g.commands, &GithubCommandUpdateRepositoryCodeowners{
+		client:      g.client,
+		dryrun:      dryrun,
+		reponame:    reponame,
+		content:     content,
+		existingSHA: existingSHA,
+	})
+}
+
 func (g *GithubBatchExecutor) UpdateRepositorySetExternalUser(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, githubid string, permission string) {
 	g.commands = append(g.commands, &GithubCommandUpdateRepositorySetExternalUser{
 		client:     g.client,
@@ -635,6 +650,18 @@ type GithubCommandUpdateRepositoryTopics struct {
 
 func (g *GithubCommandUpdateRepositoryTopics) Apply(ctx context.Context, logsCollector *observability.LogCollection) {
 	g.client.UpdateRepositoryTopics(ctx, logsCollector, g.dryrun, g.reponame, g.topics)
+}
+
+type GithubCommandUpdateRepositoryCodeowners struct {
+	client      engine.ReconciliatorExecutor
+	dryrun      bool
+	reponame    string
+	content     string
+	existingSHA string
+}
+
+func (g *GithubCommandUpdateRepositoryCodeowners) Apply(ctx context.Context, logsCollector *observability.LogCollection) {
+	g.client.UpdateRepositoryCodeowners(ctx, logsCollector, g.dryrun, g.reponame, g.content, g.existingSHA)
 }
 
 type GithubCommandUpdateTeamAddMember struct {

--- a/internal/goliac_server.go
+++ b/internal/goliac_server.go
@@ -936,16 +936,16 @@ func (g *GoliacServerImpl) Serve() {
 func (g *GoliacServerImpl) handleIssueComment(ctx context.Context, organization, repository, prUrl, githubIdCaller, comment string, comment_id int) {
 	logrus.Debugf("Issue comment event received for organization %s, repository %s, githubIdCaller %s, prUrl %s, comment %s", organization, repository, githubIdCaller, prUrl, comment)
 
+	if strings.HasPrefix(comment, "/help") {
+		g.handleIssueCommandHelp(ctx, organization, repository, prUrl, githubIdCaller)
+		return
+	}
+
 	// check if the comment is a command to apply
 	commandRegex := regexp.MustCompile(`^/([a-zA-Z0-9_-]+):?(.*)`)
 	matches := commandRegex.FindStringSubmatch(comment)
 	if len(matches) == 3 {
 		command := matches[1]
-
-		if command == "help" {
-			g.handleIssueCommandHelp(ctx, organization, repository, prUrl, githubIdCaller)
-			return
-		}
 
 		// looking for something like "/forcemerge:default: an explanation"
 		commentRegex := regexp.MustCompile(`^/([a-zA-Z0-9_-]+):([a-zA-Z0-9_-]+):(.*)`)

--- a/internal/goliac_server.go
+++ b/internal/goliac_server.go
@@ -942,6 +942,11 @@ func (g *GoliacServerImpl) handleIssueComment(ctx context.Context, organization,
 	if len(matches) == 3 {
 		command := matches[1]
 
+		if command == "help" {
+			g.handleIssueCommandHelp(ctx, organization, repository, prUrl, githubIdCaller)
+			return
+		}
+
 		// looking for something like "/forcemerge:default: an explanation"
 		commentRegex := regexp.MustCompile(`^/([a-zA-Z0-9_-]+):([a-zA-Z0-9_-]+):(.*)`)
 		comment = strings.Trim(comment, " \r\n\t")
@@ -1045,6 +1050,41 @@ func (g *GoliacServerImpl) handleIssueCommandExecuteWorkflow(ctx context.Context
 				}
 			}
 		}
+	}
+}
+
+// handleIssueCommandHelp handles the /help command and lists all available workflows with example usage
+func (g *GoliacServerImpl) handleIssueCommandHelp(ctx context.Context, organization, repository, prUrl, githubIdCaller string) {
+	enabledWorkflows := g.goliac.GetLocal().RepoConfig().Workflows
+	if len(enabledWorkflows) == 0 {
+		comment := "No workflow enabled. Check with your administrator."
+		err := g.CreateComment(ctx, organization, repository, prUrl, githubIdCaller, comment)
+		if err != nil {
+			logrus.Error("error when creating 'no workflows enabled' comment: " + err.Error())
+		}
+		return
+	}
+
+	comment := "Available Goliac commands:\n\n"
+	comment += "| Command | Description |\n"
+	comment += "|---------|-------------|\n"
+
+	for _, workflowName := range enabledWorkflows {
+		for name, workflow := range g.goliac.GetLocal().Workflows() {
+			if name == workflowName {
+				comment += fmt.Sprintf("| `/%s:%s: <explanation>` | %s |\n", workflow.Spec.WorkflowType, workflow.Name, workflow.Spec.Description)
+			}
+		}
+	}
+
+	comment += "\nExample:\n"
+	comment += "```\n"
+	comment += "/forcemerge:standard: hotfix for production outage\n"
+	comment += "```\n"
+
+	err := g.CreateComment(ctx, organization, repository, prUrl, githubIdCaller, comment)
+	if err != nil {
+		logrus.Error("error when creating 'help' comment: " + err.Error())
 	}
 }
 

--- a/internal/goliac_server_test.go
+++ b/internal/goliac_server_test.go
@@ -596,4 +596,23 @@ func TestHandleIssueComment(t *testing.T) {
 		server.handleIssueComment(context.Background(), "org", "repoB", "https://github.com/org/repoB/pull/123", "userE1", "/forcemerge", 123)
 		assert.Equal(t, "Available workflows:\n- `/forcemerge:fmtest: <explanation>`\n", githubClient.lastBody["body"])
 	})
+
+	t.Run("happy path: handle /help command", func(t *testing.T) {
+		localfixture, remotefixture := fixtureGoliacLocal()
+		githubClient := &GithubClientMock{}
+		fmtest := WorkflowMock{}
+		goliac := NewGoliacMock(localfixture, remotefixture, githubClient)
+		server := GoliacServerImpl{
+			goliac: goliac,
+			worflowInstances: map[string]workflow.Workflow{
+				"forcemerge": &fmtest,
+			},
+		}
+
+		server.handleIssueComment(context.Background(), "org", "repoB", "https://github.com/org/repoB/pull/123", "userE1", "/help", 123)
+		body := githubClient.lastBody["body"].(string)
+		assert.Contains(t, body, "Available Goliac commands:")
+		assert.Contains(t, body, "/forcemerge:fmtest:")
+		assert.Contains(t, body, "Example:")
+	})
 }

--- a/internal/goliac_server_test.go
+++ b/internal/goliac_server_test.go
@@ -615,4 +615,23 @@ func TestHandleIssueComment(t *testing.T) {
 		assert.Contains(t, body, "/forcemerge:fmtest:")
 		assert.Contains(t, body, "Example:")
 	})
+
+	t.Run("happy path: handle /help prefix command", func(t *testing.T) {
+		localfixture, remotefixture := fixtureGoliacLocal()
+		githubClient := &GithubClientMock{}
+		fmtest := WorkflowMock{}
+		goliac := NewGoliacMock(localfixture, remotefixture, githubClient)
+		server := GoliacServerImpl{
+			goliac: goliac,
+			worflowInstances: map[string]workflow.Workflow{
+				"forcemerge": &fmtest,
+			},
+		}
+
+		server.handleIssueComment(context.Background(), "org", "repoB", "https://github.com/org/repoB/pull/123", "userE1", "/help forcemerge", 123)
+		body := githubClient.lastBody["body"].(string)
+		assert.Contains(t, body, "Available Goliac commands:")
+		assert.Contains(t, body, "/forcemerge:fmtest:")
+		assert.Contains(t, body, "Example:")
+	})
 }

--- a/internal/goliac_test.go
+++ b/internal/goliac_test.go
@@ -655,6 +655,13 @@ func (e *GoliacRemoteExecutorMock) UpdateRepositoryTopics(ctx context.Context, l
 	fmt.Println("*** UpdateRepositoryTopics", reponame, topics)
 	e.nbChanges++
 }
+func (e *GoliacRemoteExecutorMock) GetRepositoryCodeowners(ctx context.Context, reponame string) (string, string, error) {
+	return "", "", nil
+}
+func (e *GoliacRemoteExecutorMock) UpdateRepositoryCodeowners(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, content string, existingSHA string) {
+	fmt.Println("*** UpdateRepositoryCodeowners", reponame)
+	e.nbChanges++
+}
 func (e *GoliacRemoteExecutorMock) UpdateRepositoryAddTeamAccess(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, teamslug string, permission string) {
 	fmt.Println("*** UpdateRepositoryAddTeamAccess", reponame, teamslug, permission)
 	e.nbChanges++


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds automated `.github/CODEOWNERS` generation and GitHub content updates, which changes reconciliation behavior and performs new write operations to repositories. Also tweaks PR command parsing to intercept `/help`, which could affect issue comment workflow handling if edge cases exist.
> 
> **Overview**
> **Adds first-class CODEOWNERS management.** Repository YAML now supports `spec.codeowners` (validated team references) and `spec.codeowners_raw` (verbatim), with `Repository.GenerateCodeownersContent()` producing a canonical `.github/CODEOWNERS` (header + sorted rules) and new validation/tests.
> 
> **Extends reconciliation to sync `.github/CODEOWNERS` on GitHub.** The reconciler now compares desired vs remote CODEOWNERS and, when configured, fetches/updates the file via new executor methods implemented in the remote (REST `contents` API) and batch executor (new queued command).
> 
> **Improves PR comment UX.** Issue comment handling now supports a `/help` command that posts a table of enabled workflow commands with an example; tests updated accordingly, and docs/changelog updated for v1.7.0.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cc181a68baf03bf247f54a43717e9ec3449eef1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->