### PR TITLE
V1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Goliac v1.7.1
+
+- remove deleted teams from managed codeowner
+- fix loading of codeowners file
+
 ## Goliac v1.7.0
 
 - add codeowner support

--- a/internal/engine/remote.go
+++ b/internal/engine/remote.go
@@ -1555,8 +1555,10 @@ func (g *GoliacRemoteImpl) loadVariablesPerRepository(ctx context.Context, repos
 	return variables, nil
 }
 
-// loadRepositoryCodeownersConcurrently fetches .github/CODEOWNERS for each repository so remote
-// comparisons and reconciliation use the same content as GitHub (not only after an apply).
+// loadRepositoryCodeownersConcurrently fetches .github/CODEOWNERS for each non-archived repository
+// so remote comparisons and reconciliation use the same content as GitHub (not only after an apply).
+// Archived repositories are skipped (CodeownersContent remains empty). Any error from
+// GetRepositoryCodeowners fails the whole operation.
 func (g *GoliacRemoteImpl) loadRepositoryCodeownersConcurrently(ctx context.Context, maxGoroutines int64, repositories map[string]*GithubRepository) error {
 	var childSpan trace.Span
 	if config.Config.OpenTelemetryEnabled {
@@ -1597,6 +1599,9 @@ func (g *GoliacRemoteImpl) loadRepositoryCodeownersConcurrently(ctx context.Cont
 	}
 
 	for _, repo := range repositories {
+		if repo.BoolProperties["archived"] {
+			continue
+		}
 		reposChan <- repo
 	}
 	close(reposChan)

--- a/internal/engine/remote.go
+++ b/internal/engine/remote.go
@@ -1119,6 +1119,13 @@ func (g *GoliacRemoteImpl) loadRepositories(ctx context.Context, githubToken *st
 		}
 	}
 
+	if err := g.loadRepositoryCodeownersConcurrently(ctx, config.Config.GithubConcurrentThreads, repositories); err != nil {
+		logrus.Warnf("error loading CODEOWNERS: %v", err)
+		if retErr == nil {
+			retErr = fmt.Errorf("error loading repository CODEOWNERS: %w", err)
+		}
+	}
+
 	return repositories, repositoriesByRefId, retErr
 }
 
@@ -1546,6 +1553,62 @@ func (g *GoliacRemoteImpl) loadVariablesPerRepository(ctx context.Context, repos
 	}
 
 	return variables, nil
+}
+
+// loadRepositoryCodeownersConcurrently fetches .github/CODEOWNERS for each repository so remote
+// comparisons and reconciliation use the same content as GitHub (not only after an apply).
+func (g *GoliacRemoteImpl) loadRepositoryCodeownersConcurrently(ctx context.Context, maxGoroutines int64, repositories map[string]*GithubRepository) error {
+	var childSpan trace.Span
+	if config.Config.OpenTelemetryEnabled {
+		ctx, childSpan = otel.Tracer("goliac").Start(ctx, "loadRepositoryCodeowners")
+		defer childSpan.End()
+	}
+	logrus.Debug("loading repository CODEOWNERS files")
+
+	var wg sync.WaitGroup
+
+	reposChan := make(chan *GithubRepository, len(repositories))
+	errChan := make(chan error, 1)
+
+	if maxGoroutines < 1 {
+		maxGoroutines = 1
+	}
+
+	for i := int64(0); i < maxGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for repo := range reposChan {
+				content, sha, err := g.GetRepositoryCodeowners(ctx, repo.Name)
+				if err != nil {
+					select {
+					case errChan <- fmt.Errorf("CODEOWNERS for %s: %w", repo.Name, err):
+					default:
+					}
+					return
+				}
+				repo.CodeownersContent = content
+				repo.CodeownersSHA = sha
+				if g.feedback != nil {
+					g.feedback.LoadingAsset("repo_codeowners", 1)
+				}
+			}
+		}()
+	}
+
+	for _, repo := range repositories {
+		reposChan <- repo
+	}
+	close(reposChan)
+
+	wg.Wait()
+
+	select {
+	case err := <-errChan:
+		return err
+	default:
+		return nil
+	}
 }
 
 func (g *GoliacRemoteImpl) loadCustomPropertiesConcurrently(ctx context.Context, maxGoroutines int64, repositories map[string]*GithubRepository) (map[string]map[string]interface{}, error) {

--- a/internal/engine/remote_test.go
+++ b/internal/engine/remote_test.go
@@ -408,6 +408,9 @@ func (m *MockGithubClient) CallRestAPI(ctx context.Context, endpoint, parameters
 		if strings.HasSuffix(endpoint, "/environments") {
 			return []byte(`{"total_count": 2, "environments": [{"id": 1, "name": "production", "node_id": "123", "protection_rules": [{"id": 1, "type": "required_reviewers", "reviewer_teams": ["team1"]}]}, {"id": 2, "name": "staging", "node_id": "456", "protection_rules": []}]}`), nil
 		}
+		if strings.HasSuffix(endpoint, "/contents/.github/CODEOWNERS") {
+			return nil, fmt.Errorf("404 Not Found")
+		}
 		// we still pretend we have 133 teams, cf L263
 		repoSuffix := strings.TrimPrefix(endpoint, "/repos/myorg/repo_")
 		repoIdStr := strings.Split(repoSuffix, "/")[0]

--- a/internal/entity/repository.go
+++ b/internal/entity/repository.go
@@ -535,10 +535,59 @@ func (r *Repository) GenerateCodeownersContent(githubOrganization string) string
 	return sb.String()
 }
 
+// collectExistingTeamNames walks teamDirname like ReadAndAdjustTeamDirectory and records each
+// team.yaml `name` field. Used to prune spec.codeowners entries that reference deleted teams.
+func collectExistingTeamNames(fs billy.Filesystem, teamDirname string) (map[string]struct{}, error) {
+	out := make(map[string]struct{})
+	exist, err := utils.Exists(fs, teamDirname)
+	if err != nil {
+		return nil, err
+	}
+	if !exist {
+		return out, nil
+	}
+	entries, err := fs.ReadDir(teamDirname)
+	if err != nil {
+		return nil, err
+	}
+	for _, e := range entries {
+		if !e.IsDir() || e.Name()[0] == '.' {
+			continue
+		}
+		if err := recursiveCollectExistingTeamNames(fs, filepath.Join(teamDirname, e.Name()), out); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+func recursiveCollectExistingTeamNames(fs billy.Filesystem, dirname string, out map[string]struct{}) error {
+	team, err := NewTeam(fs, filepath.Join(dirname, "team.yaml"), nil)
+	if err != nil {
+		return err
+	}
+	out[team.Name] = struct{}{}
+
+	entries, err := fs.ReadDir(dirname)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if !e.IsDir() || e.Name()[0] == '.' {
+			continue
+		}
+		if err := recursiveCollectExistingTeamNames(fs, filepath.Join(dirname, e.Name()), out); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 /**
- * ReadAndAdjustRepositories adjusts repository definitions depending on user availability.
- * The goal is that if a user has been removed, we must update the repository definition
- * by removing them from branch_protections bypass_pullrequest_users.
+ * ReadAndAdjustRepositories adjusts repository definitions depending on user availability and
+ * which teams still exist under teamDirname. It removes users from branch_protections
+ * bypass_pullrequest_users when they no longer exist, and removes team references from
+ * spec.codeowners when those teams no longer exist.
  * Returns:
  * - a list of (repository's) file changes (to commit to Github)
  */
@@ -552,6 +601,11 @@ func ReadAndAdjustRepositories(fs billy.Filesystem, archivedDirname string, team
 	}
 	for k, v := range externalUsers {
 		allUsers[k] = v
+	}
+
+	existingTeams, err := collectExistingTeamNames(fs, teamDirname)
+	if err != nil {
+		return reposChanged, err
 	}
 
 	// archived dir
@@ -580,7 +634,7 @@ func ReadAndAdjustRepositories(fs billy.Filesystem, archivedDirname string, team
 			if err != nil {
 				continue
 			}
-			changed, err := repo.Update(fs, filepath.Join(archivedDirname, entry.Name()), allUsers)
+			changed, err := repo.Update(fs, filepath.Join(archivedDirname, entry.Name()), allUsers, existingTeams)
 			if err != nil {
 				return reposChanged, err
 			}
@@ -607,7 +661,7 @@ func ReadAndAdjustRepositories(fs billy.Filesystem, archivedDirname string, team
 
 	for _, team := range entries {
 		if team.IsDir() {
-			err := recursiveReadAndAdjustRepositories(fs, archivedDirname, filepath.Join(teamDirname, team.Name()), allUsers, &reposChanged)
+			err := recursiveReadAndAdjustRepositories(fs, archivedDirname, filepath.Join(teamDirname, team.Name()), allUsers, existingTeams, &reposChanged)
 			if err != nil {
 				return reposChanged, err
 			}
@@ -617,14 +671,14 @@ func ReadAndAdjustRepositories(fs billy.Filesystem, archivedDirname string, team
 	return reposChanged, nil
 }
 
-func recursiveReadAndAdjustRepositories(fs billy.Filesystem, archivedDirPath string, teamDirPath string, allUsers map[string]*User, reposChanged *[]string) error {
+func recursiveReadAndAdjustRepositories(fs billy.Filesystem, archivedDirPath string, teamDirPath string, allUsers map[string]*User, existingTeams map[string]struct{}, reposChanged *[]string) error {
 	subentries, err := fs.ReadDir(teamDirPath)
 	if err != nil {
 		return err
 	}
 	for _, sube := range subentries {
 		if sube.IsDir() && sube.Name()[0] != '.' {
-			err := recursiveReadAndAdjustRepositories(fs, archivedDirPath, filepath.Join(teamDirPath, sube.Name()), allUsers, reposChanged)
+			err := recursiveReadAndAdjustRepositories(fs, archivedDirPath, filepath.Join(teamDirPath, sube.Name()), allUsers, existingTeams, reposChanged)
 			if err != nil {
 				return err
 			}
@@ -637,7 +691,7 @@ func recursiveReadAndAdjustRepositories(fs billy.Filesystem, archivedDirPath str
 			if err != nil {
 				continue
 			}
-			changed, err := repo.Update(fs, filepath.Join(teamDirPath, sube.Name()), allUsers)
+			changed, err := repo.Update(fs, filepath.Join(teamDirPath, sube.Name()), allUsers, existingTeams)
 			if err != nil {
 				return err
 			}
@@ -650,9 +704,9 @@ func recursiveReadAndAdjustRepositories(fs billy.Filesystem, archivedDirPath str
 }
 
 // Update is telling if the repository needs to be adjusted (and the repository's definition was changed on disk),
-// based on the list of (still) existing users. It removes users from branch_protections bypass_pullrequest_users
-// if they don't exist in the users map.
-func (r *Repository) Update(fs billy.Filesystem, filename string, allUsers map[string]*User) (bool, error) {
+// based on the list of (still) existing users and teams. It removes users from branch_protections bypass_pullrequest_users
+// if they don't exist in the users map, and removes team owners from spec.codeowners if those teams no longer exist.
+func (r *Repository) Update(fs billy.Filesystem, filename string, allUsers map[string]*User, existingTeams map[string]struct{}) (bool, error) {
 	changed := false
 
 	// Update branch protections bypass_pullrequest_users
@@ -668,6 +722,38 @@ func (r *Repository) Update(fs billy.Filesystem, filename string, allUsers map[s
 		}
 		bp.BypassPullRequestUsers = validUsers
 	}
+
+	// Update spec.codeowners: drop unknown teams (owners without @ prefix)
+	var newCodeowners []RepositoryCodeownersEntry
+	for _, entry := range r.Spec.Codeowners {
+		validOwners := make([]string, 0, len(entry.Owners))
+		for _, owner := range entry.Owners {
+			if strings.HasPrefix(owner, "@") {
+				validOwners = append(validOwners, owner)
+			} else if _, ok := existingTeams[owner]; ok {
+				validOwners = append(validOwners, owner)
+			} else {
+				changed = true
+			}
+		}
+		if len(validOwners) == 0 {
+			if len(entry.Owners) > 0 {
+				changed = true
+			}
+			continue
+		}
+		if len(validOwners) != len(entry.Owners) {
+			changed = true
+		}
+		newCodeowners = append(newCodeowners, RepositoryCodeownersEntry{
+			Pattern: entry.Pattern,
+			Owners:  validOwners,
+		})
+	}
+	if len(newCodeowners) != len(r.Spec.Codeowners) {
+		changed = true
+	}
+	r.Spec.Codeowners = newCodeowners
 
 	if !changed {
 		return false, nil

--- a/internal/entity/repository_test.go
+++ b/internal/entity/repository_test.go
@@ -626,7 +626,18 @@ func TestReadAndAdjustRepositories(t *testing.T) {
 		users["user1"] = user1
 
 		fs.MkdirAll("teams/team1", 0755)
-		err := utils.WriteFile(fs, "teams/team1/repo1.yaml", []byte(`
+		err := utils.WriteFile(fs, "teams/team1/team.yaml", []byte(`
+apiVersion: v1
+kind: Team
+name: team1
+spec:
+  externallyManaged: true
+  owners:
+  - user1
+  - user1
+`), 0644)
+		assert.Nil(t, err)
+		err = utils.WriteFile(fs, "teams/team1/repo1.yaml", []byte(`
 apiVersion: v1
 kind: Repository
 name: repo1
@@ -653,7 +664,18 @@ spec:
 		users["user1"] = user1
 
 		fs.MkdirAll("teams/team1", 0755)
-		err := utils.WriteFile(fs, "teams/team1/repo1.yaml", []byte(`
+		err := utils.WriteFile(fs, "teams/team1/team.yaml", []byte(`
+apiVersion: v1
+kind: Team
+name: team1
+spec:
+  externallyManaged: true
+  owners:
+  - user1
+  - user1
+`), 0644)
+		assert.Nil(t, err)
+		err = utils.WriteFile(fs, "teams/team1/repo1.yaml", []byte(`
 apiVersion: v1
 kind: Repository
 name: repo1
@@ -688,7 +710,18 @@ spec:
 		externalUsers["externaluser1"] = externalUser1
 
 		fs.MkdirAll("teams/team1", 0755)
-		err := utils.WriteFile(fs, "teams/team1/repo1.yaml", []byte(`
+		err := utils.WriteFile(fs, "teams/team1/team.yaml", []byte(`
+apiVersion: v1
+kind: Team
+name: team1
+spec:
+  externallyManaged: true
+  owners:
+  - user1
+  - user1
+`), 0644)
+		assert.Nil(t, err)
+		err = utils.WriteFile(fs, "teams/team1/repo1.yaml", []byte(`
 apiVersion: v1
 kind: Repository
 name: repo1
@@ -743,5 +776,124 @@ spec:
 		assert.Nil(t, err)
 		assert.Contains(t, string(content), "user1")
 		assert.NotContains(t, string(content), "user2")
+	})
+
+	t.Run("happy path: remove deleted team from spec.codeowners", func(t *testing.T) {
+		fs := memfs.New()
+		users := make(map[string]*User)
+
+		fs.MkdirAll("teams/team1", 0755)
+		err := utils.WriteFile(fs, "teams/team1/team.yaml", []byte(`
+apiVersion: v1
+kind: Team
+name: team1
+spec:
+  externallyManaged: true
+  owners:
+  - user1
+  - user1
+`), 0644)
+		assert.Nil(t, err)
+		err = utils.WriteFile(fs, "teams/team1/repo1.yaml", []byte(`
+apiVersion: v1
+kind: Repository
+name: repo1
+spec:
+  codeowners:
+    - pattern: /
+      owners:
+        - team1
+        - ghost-team
+`), 0644)
+		assert.Nil(t, err)
+
+		changed, err := ReadAndAdjustRepositories(fs, "archived", "teams", users, map[string]*User{})
+		assert.Nil(t, err)
+		assert.Equal(t, 1, len(changed))
+
+		content, err := utils.ReadFile(fs, "teams/team1/repo1.yaml")
+		assert.Nil(t, err)
+		assert.Contains(t, string(content), "team1")
+		assert.NotContains(t, string(content), "ghost-team")
+	})
+
+	t.Run("happy path: spec.codeowners keeps @ user and drops deleted team", func(t *testing.T) {
+		fs := memfs.New()
+		users := make(map[string]*User)
+
+		fs.MkdirAll("teams/team1", 0755)
+		err := utils.WriteFile(fs, "teams/team1/team.yaml", []byte(`
+apiVersion: v1
+kind: Team
+name: team1
+spec:
+  externallyManaged: true
+  owners:
+  - user1
+  - user1
+`), 0644)
+		assert.Nil(t, err)
+		err = utils.WriteFile(fs, "teams/team1/repo1.yaml", []byte(`
+apiVersion: v1
+kind: Repository
+name: repo1
+spec:
+  codeowners:
+    - pattern: /src/
+      owners:
+        - "@githubuser"
+        - ghost-team
+`), 0644)
+		assert.Nil(t, err)
+
+		changed, err := ReadAndAdjustRepositories(fs, "archived", "teams", users, map[string]*User{})
+		assert.Nil(t, err)
+		assert.Equal(t, 1, len(changed))
+
+		content, err := utils.ReadFile(fs, "teams/team1/repo1.yaml")
+		assert.Nil(t, err)
+		assert.Contains(t, string(content), "@githubuser")
+		assert.NotContains(t, string(content), "ghost-team")
+	})
+
+	t.Run("happy path: archived repository strips missing team from spec.codeowners", func(t *testing.T) {
+		fs := memfs.New()
+		users := make(map[string]*User)
+
+		fs.MkdirAll("teams/team1", 0755)
+		err := utils.WriteFile(fs, "teams/team1/team.yaml", []byte(`
+apiVersion: v1
+kind: Team
+name: team1
+spec:
+  externallyManaged: true
+  owners:
+  - user1
+  - user1
+`), 0644)
+		assert.Nil(t, err)
+
+		fs.MkdirAll("archived", 0755)
+		err = utils.WriteFile(fs, "archived/repo1.yaml", []byte(`
+apiVersion: v1
+kind: Repository
+name: repo1
+spec:
+  codeowners:
+    - pattern: /
+      owners:
+        - team1
+        - other-team
+`), 0644)
+		assert.Nil(t, err)
+
+		changed, err := ReadAndAdjustRepositories(fs, "archived", "teams", users, map[string]*User{})
+		assert.Nil(t, err)
+		assert.Equal(t, 1, len(changed))
+
+		content, err := utils.ReadFile(fs, "archived/repo1.yaml")
+		assert.Nil(t, err)
+		assert.Contains(t, string(content), "team1")
+		assert.NotContains(t, string(content), "other-team")
 	})
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds concurrent remote fetching of `.github/CODEOWNERS` during repository loading, which increases GitHub API usage and can now surface load-time errors. Also mutates repo YAMLs by pruning stale `spec.codeowners` team references, so reconciliation behavior and generated diffs may change.
> 
> **Overview**
> **Improves CODEOWNERS handling in both local specs and remote state.** Repository loading now concurrently fetches each non-archived repo’s `.github/CODEOWNERS` and stores its content/SHA so comparisons/reconciliation use the live GitHub file (with 404 treated as “no CODEOWNERS”).
> 
> **Cleans up managed codeowners on disk.** `ReadAndAdjustRepositories` now scans `teams/**/team.yaml` to derive existing team names and removes deleted-team references from `spec.codeowners` (preserving owners prefixed with `@`), updating affected repo YAMLs; tests and changelog are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0eeeddacfb490d0df64385b4807b5a2340cdac26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->