### PR TITLE
V1 7 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Goliac v1.7.2
+
+- validate that teams in codeowners are writer of the repo
+- fix 409 Conflict on codeowners update
+
 ## Goliac v1.7.1
 
 - remove deleted teams from managed codeowner

--- a/internal/engine/remote.go
+++ b/internal/engine/remote.go
@@ -3860,14 +3860,14 @@ func (g *GoliacRemoteImpl) CreateRepository(ctx context.Context, logsCollector *
 
 	// update the repositories list
 	newRepo := &GithubRepository{
-		Name:                reponame,
-		Id:                  repoId,
-		RefId:               repoRefId,
-		Visibility:          visibility,
-		BoolProperties:      boolProperties,
-		DefaultBranchName:   defaultBranch,
-		IsFork:              forkFrom != "",
-		RuleSets:            make(map[string]*GithubRuleSet),
+		Name:              reponame,
+		Id:                repoId,
+		RefId:             repoRefId,
+		Visibility:        visibility,
+		BoolProperties:    boolProperties,
+		DefaultBranchName: defaultBranch,
+		IsFork:            forkFrom != "",
+		RuleSets:          make(map[string]*GithubRuleSet),
 	}
 	g.repositories[reponame] = newRepo
 	g.repositoriesByRefId[repoRefId] = newRepo

--- a/internal/entity/repository.go
+++ b/internal/entity/repository.go
@@ -246,6 +246,8 @@ func recursiveReadRepositories(fs billy.Filesystem, archivedDirPath string, team
 			if err != nil {
 				LogCollection.AddError(err)
 			} else {
+				teamname := teamName
+				repo.Owner = &teamname
 				if err := repo.Validate(filepath.Join(teamDirPath, sube.Name()), teams, externalUsers, users, customProperties); err != nil {
 					LogCollection.AddError(err)
 				} else {
@@ -257,8 +259,6 @@ func recursiveReadRepositories(fs billy.Filesystem, archivedDirPath string, team
 						}
 						LogCollection.AddError(fmt.Errorf("Repository %s defined in 2 places (check %s and %s)", repo.Name, filepath.Join(teamDirPath, sube.Name()), existing))
 					} else {
-						teamname := teamName
-						repo.Owner = &teamname
 						repo.Archived = false
 						repos[repo.Name] = repo
 					}
@@ -301,6 +301,13 @@ func (r *Repository) Validate(filename string, teams map[string]*Team, externalU
 		if _, ok := teams[reader]; !ok {
 			return fmt.Errorf("invalid reader: %s doesn't exist (check repository filename %s)", reader, filename)
 		}
+	}
+	writersSet := make(map[string]struct{}, len(r.Spec.Writers))
+	for _, writer := range r.Spec.Writers {
+		writersSet[writer] = struct{}{}
+	}
+	if r.Owner != nil && *r.Owner != "" {
+		writersSet[*r.Owner] = struct{}{}
 	}
 
 	for _, externalUserReader := range r.Spec.ExternalUserReaders {
@@ -427,6 +434,10 @@ func (r *Repository) Validate(filename string, teams map[string]*Team, externalU
 			// otherwise it must be a team name
 			if _, ok := teams[owner]; !ok {
 				return fmt.Errorf("invalid codeowners owner: team %s doesn't exist (check repository filename %s)", owner, filename)
+			}
+			// team owners must have write permission on the repository
+			if _, ok := writersSet[owner]; !ok {
+				return fmt.Errorf("invalid codeowners owner: team %s must be listed in writers (check repository filename %s)", owner, filename)
 			}
 		}
 	}

--- a/internal/entity/repository_test.go
+++ b/internal/entity/repository_test.go
@@ -449,6 +449,33 @@ apiVersion: v1
 kind: Repository
 name: repo1
 spec:
+  writers:
+    - team1
+  codeowners:
+    - pattern: "*"
+      owners:
+        - team1
+`), 0644)
+		assert.Nil(t, err)
+
+		logsCollector := observability.NewLogCollection()
+		users := ReadUserDirectory(fs, "users", logsCollector)
+		teams := ReadTeamDirectory(fs, "teams", users, logsCollector)
+		repos := ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, users, []*config.GithubCustomProperty{}, logsCollector)
+		assert.False(t, logsCollector.HasErrors())
+		assert.Equal(t, 1, len(repos))
+	})
+
+	t.Run("happy path: codeowners with owning team and no writers", func(t *testing.T) {
+		fs := memfs.New()
+		fixtureCreateUserTeam(t, fs)
+
+		err := utils.WriteFile(fs, "teams/team1/repo1.yaml", []byte(`
+apiVersion: v1
+kind: Repository
+name: repo1
+spec:
+  writers: []
   codeowners:
     - pattern: "*"
       owners:
@@ -501,6 +528,39 @@ spec:
     - pattern: "*"
       owners:
         - nonexistent-team
+`), 0644)
+		assert.Nil(t, err)
+
+		logsCollector := observability.NewLogCollection()
+		users := ReadUserDirectory(fs, "users", logsCollector)
+		teams := ReadTeamDirectory(fs, "teams", users, logsCollector)
+		ReadRepositories(fs, "archived", "teams", teams, map[string]*User{}, users, []*config.GithubCustomProperty{}, logsCollector)
+		assert.True(t, logsCollector.HasErrors())
+	})
+
+	t.Run("not happy path: codeowners team must be repository writer", func(t *testing.T) {
+		fs := memfs.New()
+		fixtureCreateUserTeam(t, fs)
+		err := utils.WriteFile(fs, "teams/team2/team.yaml", []byte(`
+apiVersion: v1
+kind: Team
+name: team2
+spec:
+  owners:
+    - user1
+`), 0644)
+		assert.Nil(t, err)
+
+		err = utils.WriteFile(fs, "teams/team1/repo1.yaml", []byte(`
+apiVersion: v1
+kind: Repository
+name: repo1
+spec:
+  writers: []
+  codeowners:
+    - pattern: "*"
+      owners:
+        - team2
 `), 0644)
 		assert.Nil(t, err)
 
@@ -566,6 +626,8 @@ apiVersion: v1
 kind: Repository
 name: repo1
 spec:
+  writers:
+    - team1
   codeowners:
     - pattern: "*"
       owners:

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -52,8 +52,8 @@ type AuthorizedTransport struct {
 func (t *AuthorizedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	t.client.mu.Lock()
 
-	// Use the personal access token if available
-	if t.client.patToken != "" {
+	// Use the personal access token if available and private key is not set
+	if t.client.patToken != "" && t.client.privateKey == nil {
 		req.Header.Add("Authorization", "Bearer "+t.client.patToken)
 		t.client.mu.Unlock()
 		return http.DefaultTransport.RoundTrip(req)
@@ -180,7 +180,7 @@ func waitRateLimit(resetTimeStr string) error {
 		return fmt.Errorf("failed to parse X-RateLimit-Reset header: %w", err)
 	}
 
-	resetTime := time.Unix(resetTimeUnix, 0)
+	resetTime := time.Unix(resetTimeUnix+1, 0)
 
 	// Calculate how long we need to wait.
 	waitDuration := time.Until(resetTime)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk: tightens repository validation (may cause previously-accepted `codeowners` configs to fail) and adjusts GitHub auth selection logic, which could change how requests are authenticated in some deployments.
> 
> **Overview**
> **CODEOWNERS validation is tightened** so any team referenced in `spec.codeowners` must both exist *and* be a repository writer (the owning team now implicitly counts as a writer during validation). Tests are updated/added to cover the new writer/owner requirements.
> 
> **GitHub client behavior is hardened** by only using the PAT path when no app private key is configured, and by adding a 1-second buffer when waiting for rate-limit reset to reduce immediate re-throttling. The changelog is updated for `v1.7.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f8b5a11191ae859a70629f18e78b29a75b13966. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->