### PR TITLE
V1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Goliac v1.8.0
+
+- configure GitHub Actions environments/variables, repository autolinks, and organization custom properties via `goliac.yaml` under `features` instead of environment variables
+- **Breaking / migration:** remove `GOLIAC_MANAGE_GITHUB_ACTIONS_VARIABLES`, `GOLIAC_MANAGE_GITHUB_AUTOLINKS`, and `GOLIAC_MANAGE_ORG_CUSTOM_PROPERTIES` from your deployment; set `features.manage_github_env_and_variables`, `features.manage_github_autolinks`, and `features.manage_org_custom_properties` in `goliac.yaml`. If the `features` block is omitted, all three still default to `true` (same as the former env defaults)
+- plan/apply loads `goliac.yaml` before warming the GitHub remote cache so those flags apply to the first load
+0 update the documentation regarding Github ruleset integration issues
+
 ## Goliac v1.7.2
 
 - validate that teams in codeowners are writer of the repo

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -130,9 +130,16 @@ And it will create the corresponding structure into the "goliac-teams" directory
 
 To make Goliac working you can configure the `/goliac.yaml` file
 
+Since **v1.8.0**, optional GitHub integration toggles live under `features` in this file (they are no longer environment variables). If you omit the whole `features` block, all three flags default to `true`, matching the old defaults.
+
 ```yaml
 admin_team: goliac-admin # the name of the team (in the `/teams` directory ) that can admin this repository
 everyone_team_enabled: false # if you want all members to have read access to all repositories
+
+features: # optional; when omitted, each flag defaults to true
+  manage_github_env_and_variables: true # sync GitHub Actions environments and repository variables with the IAC model (secrets are still only read for display)
+  manage_github_autolinks: true         # sync repository autolinks with the IAC model
+  manage_org_custom_properties: true    # manage organization custom property schema and load repository custom property values from GitHub
 
 rulesets: # if you want to have organization-wide enforced rules (see the /rulesets directory)
   - default
@@ -277,8 +284,8 @@ You can run the goliac server as a service or a docker container. It needs sever
 | GOLIAC_WORKFLOW_JIRA_ATLASSIAN_DOMAIN |      | PR Breaking glass workflow - Jira plugin: company domain  |
 | GOLIAC_WORKFLOW_JIRA_EMAIL   |               | PR Breaking glass workflow - Jira plugin: email |
 | GOLIAC_WORKFLOW_JIRA_API_TOKEN |             | PR Breaking glass workflow - Jira plugin: token |
-| GOLIAC_MANAGE_GITHUB_ACTIONS_VARIABLES | true | if Goliac manage repositories environments, variables. For secrets it only scans them for display purposes |
-| GOLIAC_MANAGE_ORG_CUSTOM_PROPERTIES | true | if Goliac manage custom properties |
+
+Feature toggles for GitHub Actions environments/variables, repository autolinks, and organization custom properties are configured in `goliac.yaml` under `features` (since v1.8.0), not via environment variables.
 
 then you just need to start it with
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -117,6 +117,11 @@ In particular it will creates a `/goliac.yaml` file:
 ```yaml
 admin_team: goliac-admin
 
+features:
+  manage_github_env_and_variables: true
+  manage_github_autolinks: true
+  manage_org_custom_properties: true
+
 rulesets:
   - default
 
@@ -224,6 +229,16 @@ export GOLIAC_GITHUB_APP_ORGANIZATION=goliac-project
 ./goliac plan --repository https://github.com/goliac-project/goliac-teams --branch main
 ```
 
+if you have a Gitub ruleset integration issue, you must also provide a Github admin PAT (with 'admin:org' scope):
+
+```shell
+export GOLIAC_GITHUB_APP_ID=355525
+export GOLIAC_GITHUB_APP_PRIVATE_KEY_FILE=goliac-project-app.2023-07-03.private-key.pem
+export GOLIAC_GITHUB_APP_ORGANIZATION=goliac-project
+export GOLIAC_GITHUB_PERSONAL_ACCESS_TOKEN=ghp_...
+./goliac plan --repository https://github.com/goliac-project/goliac-teams --branch main
+```
+
 ### 5. Apply
 
 If you are happy with the new structure:
@@ -235,6 +250,17 @@ export GOLIAC_GITHUB_APP_ORGANIZATION=goliac-project
 ./goliac apply --repository https://github.com/goliac-project/goliac-teams --branch main
 ```
 
+If you have a Gitub ruleset integration issue, you must also provide a Github admin PAT (with 'admin:org' scope):
+
+```shell
+export GOLIAC_GITHUB_APP_ID=355525
+export GOLIAC_GITHUB_APP_PRIVATE_KEY_FILE=goliac-project-app.2023-07-03.private-key.pem
+export GOLIAC_GITHUB_APP_ORGANIZATION=goliac-project
+export GOLIAC_GITHUB_PERSONAL_ACCESS_TOKEN=ghp_...
+./goliac apply --repository https://github.com/goliac-project/goliac-teams --branch main
+```
+
+
 ### 6. Run the server
 
 You can run it locally
@@ -243,6 +269,7 @@ You can run it locally
 export GOLIAC_GITHUB_APP_ID=355525
 export GOLIAC_GITHUB_APP_PRIVATE_KEY_FILE=goliac-project-app.2023-07-03.private-key.pem
 export GOLIAC_GITHUB_APP_ORGANIZATION=goliac-project
+export GOLIAC_GITHUB_PERSONAL_ACCESS_TOKEN=ghp_... # if ruleset integration issue
 export GOLIAC_SERVER_GIT_REPOSITORY=https://github.com/goliac-project/goliac-teams
 #export GOLIAC_SERVER_GIT_BRANCH=main # by default it is main
 

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -22,13 +22,6 @@ var Config = struct {
 	GithubConcurrentThreads int64 `env:"GOLIAC_GITHUB_CONCURRENT_THREADS" envDefault:"5"`
 	GithubCacheTTL          int64 `env:"GOLIAC_GITHUB_CACHE_TTL" envDefault:"86400"`
 
-	// ManageGithubActionsVariables - to manage Github Actions repository variables
-	ManageGithubActionsVariables bool `env:"GOLIAC_MANAGE_GITHUB_ACTIONS_VARIABLES" envDefault:"true"`
-	// ManageGithubAutolinks - to manage Github repositoryAutolinks
-	ManageGithubAutolinks bool `env:"GOLIAC_MANAGE_GITHUB_AUTOLINKS" envDefault:"true"`
-	// ManageOrgCustomProperties - to manage Github organization custom properties
-	ManageOrgCustomProperties bool `env:"GOLIAC_MANAGE_ORG_CUSTOM_PROPERTIES" envDefault:"true"`
-
 	ServerApplyInterval int64  `env:"GOLIAC_SERVER_APPLY_INTERVAL" envDefault:"600"`
 	ServerGitRepository string `env:"GOLIAC_SERVER_GIT_REPOSITORY" envDefault:""`
 	ServerGitBranch     string `env:"GOLIAC_SERVER_GIT_BRANCH" envDefault:"main"`

--- a/internal/config/repo_config.go
+++ b/internal/config/repo_config.go
@@ -14,6 +14,13 @@ type GithubCustomProperty struct {
 	ValuesEditableBy string   `yaml:"values_editable_by,omitempty" json:"values_editable_by,omitempty"` // "org_actors", "org_and_repo_actors"
 }
 
+// GoliacFeatures toggles optional GitHub integrations (see goliac.yaml `features`).
+type GoliacFeatures struct {
+	ManageGithubEnvAndVariables bool `yaml:"manage_github_env_and_variables"`
+	ManageGithubAutolinks       bool `yaml:"manage_github_autolinks"`
+	ManageOrgCustomProperties   bool `yaml:"manage_org_custom_properties"`
+}
+
 type RepositoryConfig struct {
 	AdminTeam           string `yaml:"admin_team"`
 	EveryoneTeamEnabled bool   `yaml:"everyone_team_enabled"`
@@ -40,6 +47,7 @@ type RepositoryConfig struct {
 
 	Workflows           []string                `yaml:"workflows"`
 	OrgCustomProperties []*GithubCustomProperty `yaml:"org_custom_properties"`
+	Features            GoliacFeatures          `yaml:"features"`
 }
 
 // set default values
@@ -51,6 +59,9 @@ func (rc *RepositoryConfig) UnmarshalYAML(value *yaml.Node) error {
 	x.GithubConcurrentThreads = 4
 	x.UserSync.Plugin = "noop"
 	x.ArchiveOnDelete = true
+	x.Features.ManageGithubEnvAndVariables = true
+	x.Features.ManageGithubAutolinks = true
+	x.Features.ManageOrgCustomProperties = true
 
 	if err := value.Decode(x); err != nil {
 		return err

--- a/internal/engine/goliac_reconciliator.go
+++ b/internal/engine/goliac_reconciliator.go
@@ -24,7 +24,7 @@ type UnmanagedResources struct {
  * GoliacReconciliator is here to sync the local state to the remote state
  */
 type GoliacReconciliator interface {
-	Reconciliate(ctx context.Context, logsCollector *observability.LogCollection, local GoliacReconciliatorDatasource, remote GoliacReconciliatorDatasource, isEnterprise bool, dryrun bool, manageGithubVariables bool, manageGithubAutolinks bool) (*UnmanagedResources, map[string]*GithubRepoComparable, map[string]string, error)
+	Reconciliate(ctx context.Context, logsCollector *observability.LogCollection, local GoliacReconciliatorDatasource, remote GoliacReconciliatorDatasource, isEnterprise bool, dryrun bool, manageGithubVariables bool, manageGithubAutolinks bool, manageOrgCustomProperties bool) (*UnmanagedResources, map[string]*GithubRepoComparable, map[string]string, error)
 }
 
 type GoliacReconciliatorImpl struct {
@@ -86,7 +86,7 @@ func normalizePropertyValue(value interface{}) interface{} {
 	}
 }
 
-func (r *GoliacReconciliatorImpl) Reconciliate(ctx context.Context, logsCollector *observability.LogCollection, local GoliacReconciliatorDatasource, remote GoliacReconciliatorDatasource, isEnterprise bool, dryrun bool, manageGithubVariables bool, manageGithubAutolinks bool) (*UnmanagedResources, map[string]*GithubRepoComparable, map[string]string, error) {
+func (r *GoliacReconciliatorImpl) Reconciliate(ctx context.Context, logsCollector *observability.LogCollection, local GoliacReconciliatorDatasource, remote GoliacReconciliatorDatasource, isEnterprise bool, dryrun bool, manageGithubVariables bool, manageGithubAutolinks bool, manageOrgCustomProperties bool) (*UnmanagedResources, map[string]*GithubRepoComparable, map[string]string, error) {
 	rremote, err := NewMutableGoliacRemoteImpl(ctx, remote)
 	if err != nil {
 		return nil, nil, nil, err
@@ -113,7 +113,7 @@ func (r *GoliacReconciliatorImpl) Reconciliate(ctx context.Context, logsCollecto
 		return nil, nil, nil, err
 	}
 
-	reposToArchive, reposToRename, err := r.reconciliateRepositories(ctx, logsCollector, local, rremote, dryrun, manageGithubVariables, manageGithubAutolinks)
+	reposToArchive, reposToRename, err := r.reconciliateRepositories(ctx, logsCollector, local, rremote, dryrun, manageGithubVariables, manageGithubAutolinks, manageOrgCustomProperties)
 	if err != nil {
 		r.Rollback(ctx, logsCollector, dryrun, err)
 		return nil, nil, nil, err
@@ -127,10 +127,12 @@ func (r *GoliacReconciliatorImpl) Reconciliate(ctx context.Context, logsCollecto
 		}
 	}
 
-	err = r.reconciliateOrgCustomProperties(ctx, logsCollector, rremote, r.repoconfig, dryrun)
-	if err != nil {
-		r.Rollback(ctx, logsCollector, dryrun, err)
-		return nil, nil, nil, err
+	if manageOrgCustomProperties {
+		err = r.reconciliateOrgCustomProperties(ctx, logsCollector, rremote, r.repoconfig, dryrun)
+		if err != nil {
+			r.Rollback(ctx, logsCollector, dryrun, err)
+			return nil, nil, nil, err
+		}
 	}
 
 	return r.unmanaged, reposToArchive, reposToRename, r.Commit(ctx, logsCollector, dryrun)
@@ -387,6 +389,7 @@ func (r *GoliacReconciliatorImpl) reconciliateRepositories(
 	dryrun bool,
 	manageGithubVariables bool,
 	manageGithubAutolinks bool,
+	manageOrgCustomProperties bool,
 ) (map[string]*GithubRepoComparable, map[string]string, error) {
 
 	reposToArchive := make(map[string]*GithubRepoComparable)

--- a/internal/engine/goliac_reconciliator_test.go
+++ b/internal/engine/goliac_reconciliator_test.go
@@ -136,6 +136,10 @@ func (m *GoliacRemoteMock) CountAssets(ctx context.Context, warmup bool) (int, e
 }
 func (g *GoliacRemoteMock) SetRemoteObservability(feedback observability.RemoteObservability) {
 }
+
+func (m *GoliacRemoteMock) SetFeatureFlags(manageGithubVariables bool, manageGithubAutolinks bool, manageOrgCustomProperties bool) {
+}
+
 func (m *GoliacRemoteMock) RepositoriesSecretsPerRepository(ctx context.Context, repositoryName string) (map[string]*GithubVariable, error) {
 	return nil, nil
 }
@@ -494,7 +498,7 @@ func TestReconciliationTeam(t *testing.T) {
 		assert.Equal(t, 0, len(rTeams))
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 2 members created
 		assert.False(t, logsCollector.HasErrors())
@@ -542,7 +546,7 @@ func TestReconciliationTeam(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 2 members created
 		assert.False(t, logsCollector.HasErrors())
@@ -608,7 +612,7 @@ func TestReconciliationTeam(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 members added
 		assert.False(t, logsCollector.HasErrors())
@@ -675,7 +679,7 @@ func TestReconciliationTeam(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 members added
 		ctx := context.TODO()
@@ -727,7 +731,7 @@ func TestReconciliationTeam(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 2 members created
 		assert.False(t, logsCollector.HasErrors())
@@ -769,7 +773,7 @@ func TestReconciliationTeam(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 team deleted
 		assert.False(t, logsCollector.HasErrors())
@@ -847,7 +851,7 @@ func TestReconciliationTeam(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 0 parent updated
 		assert.False(t, logsCollector.HasErrors())
@@ -929,7 +933,7 @@ func TestReconciliationTeam(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 team parent updated
 		assert.False(t, logsCollector.HasErrors())
@@ -1043,7 +1047,7 @@ func TestReconciliationTeam(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 team parent updated
 		assert.False(t, logsCollector.HasErrors())
@@ -1080,7 +1084,7 @@ func TestReconciliationTeam(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 team deleted
 		assert.False(t, logsCollector.HasErrors())
@@ -1126,7 +1130,7 @@ func TestReconciliationRepo(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 repo created
 		assert.False(t, logsCollector.HasErrors())
@@ -1185,7 +1189,7 @@ func TestReconciliationRepo(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 repo created
 		assert.False(t, logsCollector.HasErrors())
@@ -1254,7 +1258,7 @@ func TestReconciliationRepo(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 team updated
 		assert.False(t, logsCollector.HasErrors())
@@ -1329,7 +1333,7 @@ func TestReconciliationRepo(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 team updated
 		assert.False(t, logsCollector.HasErrors())
@@ -1415,7 +1419,7 @@ func TestReconciliationRepo(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 team added
 		assert.False(t, logsCollector.HasErrors())
@@ -1505,7 +1509,7 @@ func TestReconciliationRepo(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 team removed
 		assert.False(t, logsCollector.HasErrors())
@@ -1584,7 +1588,7 @@ func TestReconciliationRepo(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 member removed
 		assert.False(t, logsCollector.HasErrors())
@@ -1672,7 +1676,7 @@ func TestReconciliationRepo(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		assert.False(t, logsCollector.HasErrors())
 		assert.Equal(t, 0, len(recorder.RepositoryCreated))
@@ -1763,7 +1767,7 @@ func TestReconciliationRepo(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		assert.False(t, logsCollector.HasErrors())
 		assert.Equal(t, 0, len(recorder.RepositoryCreated))
@@ -1846,7 +1850,7 @@ func TestReconciliationRepo(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 member removed
 		assert.False(t, logsCollector.HasErrors())
@@ -1926,7 +1930,7 @@ func TestReconciliationRepo(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 repo updated
 		assert.False(t, logsCollector.HasErrors())
@@ -2003,7 +2007,7 @@ func TestReconciliationRepo(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 repo updated
 		assert.False(t, logsCollector.HasErrors())
@@ -2083,7 +2087,7 @@ func TestReconciliationRepo(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 team updated
 		assert.False(t, logsCollector.HasErrors())
@@ -2162,7 +2166,7 @@ func TestReconciliationRepo(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 team updated
 		assert.False(t, logsCollector.HasErrors())
@@ -2247,7 +2251,7 @@ func TestReconciliationRepo(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 team updated
 		assert.False(t, logsCollector.HasErrors())
@@ -2291,7 +2295,7 @@ func TestReconciliationRepo(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 repo deleted
 		assert.False(t, logsCollector.HasErrors())
@@ -2331,7 +2335,7 @@ func TestReconciliationRepo(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		_, toArchive, _, _ := r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		_, toArchive, _, _ := r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 repo deleted
 		assert.False(t, logsCollector.HasErrors())
@@ -2372,7 +2376,7 @@ func TestReconciliationRepo(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		_, toArchive, _, _ := r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		_, toArchive, _, _ := r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 repo deleted
 		assert.False(t, logsCollector.HasErrors())
@@ -2514,7 +2518,7 @@ func TestReconciliationRepo(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		_, _, toRename, _ := r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		_, _, toRename, _ := r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 repo renamed
 		assert.False(t, logsCollector.HasErrors())
@@ -2663,7 +2667,7 @@ func TestReconciliationRepo(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 repo renamed
 		assert.False(t, logsCollector.HasErrors())
@@ -2719,7 +2723,7 @@ func TestReconciliationRulesets(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 ruleset created
 		assert.False(t, logsCollector.HasErrors())
@@ -2768,7 +2772,7 @@ func TestReconciliationRulesets(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 ruleset created
 		assert.False(t, logsCollector.HasErrors())
@@ -2825,7 +2829,7 @@ func TestReconciliationRulesets(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 ruleset created
 		assert.False(t, logsCollector.HasErrors())
@@ -2872,7 +2876,7 @@ func TestReconciliationRulesets(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 1 ruleset created
 		assert.False(t, logsCollector.HasErrors())
@@ -2944,7 +2948,7 @@ func TestReconciliationRulesets(t *testing.T) {
 
 		repoconf.Rulesets = []string{"new"}
 
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// 0 ruleset changed
 		assert.False(t, logsCollector.HasErrors())
@@ -3047,7 +3051,7 @@ func TestReconciliationRepoRulesets(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		assert.False(t, logsCollector.HasErrors())
 		assert.Equal(t, 0, len(recorder.RepositoryCreated))
@@ -3137,7 +3141,7 @@ func TestReconciliationRepoRulesets(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		assert.False(t, logsCollector.HasErrors())
 		assert.Equal(t, 0, len(recorder.RepositoryCreated))
@@ -3229,7 +3233,7 @@ func TestReconciliationRepoBranchProtection(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		assert.False(t, logsCollector.HasErrors())
 		assert.Equal(t, 0, len(recorder.RepositoryCreated))
@@ -3313,7 +3317,7 @@ func TestReconciliationRepoBranchProtection(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		assert.False(t, logsCollector.HasErrors())
 		assert.Equal(t, 0, len(recorder.RepositoryCreated))
@@ -3371,7 +3375,7 @@ func TestReconciliationRepositoryEnvironments(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// Verify environment was added
 		assert.False(t, logsCollector.HasErrors())
@@ -3426,7 +3430,7 @@ func TestReconciliationRepositoryEnvironments(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// Verify environment was removed
 		assert.False(t, logsCollector.HasErrors())
@@ -3488,7 +3492,7 @@ func TestReconciliationRepositoryEnvironments(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// Verify environment variables were updated
 		assert.False(t, logsCollector.HasErrors())
@@ -3545,7 +3549,7 @@ func TestReconciliationAutolinks(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// Verify environment was added
 		assert.False(t, logsCollector.HasErrors())
@@ -3600,7 +3604,7 @@ func TestReconciliationAutolinks(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// Verify environment was added
 		assert.False(t, logsCollector.HasErrors())
@@ -3656,7 +3660,7 @@ func TestReconciliationAutolinks(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// Verify environment was added
 		assert.False(t, logsCollector.HasErrors())
@@ -3666,10 +3670,16 @@ func TestReconciliationAutolinks(t *testing.T) {
 }
 
 func TestReconciliationCustomProperties(t *testing.T) {
+	orgPropFeatures := config.GoliacFeatures{
+		ManageGithubEnvAndVariables: true,
+		ManageGithubAutolinks:       true,
+		ManageOrgCustomProperties:   true,
+	}
 	t.Run("happy path: create new org custom property", func(t *testing.T) {
 		recorder := NewReconciliatorListenerRecorder()
 
 		repoconf := config.RepositoryConfig{
+			Features: orgPropFeatures,
 			OrgCustomProperties: []*config.GithubCustomProperty{
 				{
 					PropertyName:  "environment",
@@ -3703,7 +3713,7 @@ func TestReconciliationCustomProperties(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// Verify custom property was created
 		assert.False(t, logsCollector.HasErrors())
@@ -3718,6 +3728,7 @@ func TestReconciliationCustomProperties(t *testing.T) {
 		recorder := NewReconciliatorListenerRecorder()
 
 		repoconf := config.RepositoryConfig{
+			Features: orgPropFeatures,
 			OrgCustomProperties: []*config.GithubCustomProperty{
 				{
 					PropertyName:  "environment",
@@ -3768,7 +3779,7 @@ func TestReconciliationCustomProperties(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// Verify custom property was updated
 		assert.False(t, logsCollector.HasErrors())
@@ -3781,6 +3792,7 @@ func TestReconciliationCustomProperties(t *testing.T) {
 		recorder := NewReconciliatorListenerRecorder()
 
 		repoconf := config.RepositoryConfig{
+			Features:            orgPropFeatures,
 			OrgCustomProperties: []*config.GithubCustomProperty{},
 		}
 
@@ -3813,7 +3825,7 @@ func TestReconciliationCustomProperties(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// Verify custom property was deleted
 		assert.False(t, logsCollector.HasErrors())
@@ -3834,6 +3846,7 @@ func TestReconciliationCustomProperties(t *testing.T) {
 		}
 
 		repoconf := config.RepositoryConfig{
+			Features:            orgPropFeatures,
 			OrgCustomProperties: []*config.GithubCustomProperty{property},
 		}
 
@@ -3861,7 +3874,7 @@ func TestReconciliationCustomProperties(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// Verify no changes were made
 		assert.False(t, logsCollector.HasErrors())
@@ -3874,6 +3887,7 @@ func TestReconciliationCustomProperties(t *testing.T) {
 		recorder := NewReconciliatorListenerRecorder()
 
 		repoconf := config.RepositoryConfig{
+			Features: orgPropFeatures,
 			OrgCustomProperties: []*config.GithubCustomProperty{
 				{
 					PropertyName:  "environment",
@@ -3911,7 +3925,7 @@ func TestReconciliationCustomProperties(t *testing.T) {
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
-		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true)
+		r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
 
 		// Verify both custom properties were created
 		assert.False(t, logsCollector.HasErrors())

--- a/internal/engine/remote.go
+++ b/internal/engine/remote.go
@@ -55,6 +55,7 @@ type GoliacRemote interface {
 
 	CountAssets(ctx context.Context, warmup bool) (int, error)         // return the number of (some) assets that will be loaded (to be used with the RemoteObservability/progress bar)
 	SetRemoteObservability(feedback observability.RemoteObservability) // if you want to get feedback on the loading process
+	SetFeatureFlags(manageGithubVariables bool, manageGithubAutolinks bool, manageOrgCustomProperties bool) // needed becasue we dont know at construction what are the values
 
 	RepositoriesSecretsPerRepository(ctx context.Context, repositoryName string) (map[string]*GithubVariable, error)
 	EnvironmentSecretsPerRepository(ctx context.Context, environments []string, repositoryName string) (map[string]map[string]*GithubVariable, error)
@@ -357,6 +358,14 @@ func NewGoliacRemoteImpl(client github.GitHubClient,
 		manageGithubAutolinks:     manageGithubAutolinks,
 		manageOrgCustomProperties: manageOrgCustomProperties,
 	}
+}
+
+func (g *GoliacRemoteImpl) SetFeatureFlags(manageGithubVariables bool, manageGithubAutolinks bool, manageOrgCustomProperties bool) {
+	g.actionMutex.Lock()
+	defer g.actionMutex.Unlock()
+	g.manageGithubVariables = manageGithubVariables
+	g.manageGithubAutolinks = manageGithubAutolinks
+	g.manageOrgCustomProperties = manageOrgCustomProperties
 }
 
 func (g *GoliacRemoteImpl) IsEnterprise() bool {

--- a/internal/goliac.go
+++ b/internal/goliac.go
@@ -96,9 +96,9 @@ func NewGoliacImpl() (Goliac, error) {
 	remote := engine.NewGoliacRemoteImpl(
 		remoteGithubClient,
 		config.Config.GithubAppOrganization,
-		config.Config.ManageGithubActionsVariables,
-		config.Config.ManageGithubAutolinks,
-		config.Config.ManageOrgCustomProperties,
+		true,
+		true,
+		true,
 	)
 
 	usersync.InitPlugins(remoteGithubClient)
@@ -286,22 +286,6 @@ func (g *GoliacImpl) ExternalCreateRepository(ctx context.Context, logsCollector
 }
 
 func (g *GoliacImpl) Apply(ctx context.Context, logsCollector *observability.LogCollection, fs billy.Filesystem, dryrun bool, repositoryUrl, branch string) *engine.UnmanagedResources {
-	// warm up the cache
-
-	if len(g.local.Repositories()) == 0 || len(g.local.Teams()) == 0 || len(g.local.Users()) == 0 {
-
-		// we need to lock the actionMutex to avoid concurrent actions
-		g.actionMutex.Lock()
-		g.loadAndValidateGoliacOrganization(ctx, fs, repositoryUrl, branch, logsCollector)
-		g.local.Close(fs)
-
-		// we can unlock the actionMutex for now
-		g.actionMutex.Unlock()
-		if logsCollector.HasErrors() {
-			return nil
-		}
-	}
-
 	if !strings.HasPrefix(repositoryUrl, "https://") &&
 		!strings.HasPrefix(repositoryUrl, "inmemory:///") { // <- only for testing purposes
 		logsCollector.AddError(fmt.Errorf("local mode is not supported for plan/apply, you must specify the https url of the remote team git repository. Check the documentation"))
@@ -328,6 +312,17 @@ func (g *GoliacImpl) Apply(ctx context.Context, logsCollector *observability.Log
 
 	g.cacheDirtyAfterAction = false
 
+	g.loadAndValidateGoliacOrganization(ctx, fs, repositoryUrl, branch, logsCollector)
+	if logsCollector.HasErrors() {
+		return nil
+	}
+
+	g.remote.SetFeatureFlags(
+		g.repoconfig.Features.ManageGithubEnvAndVariables,
+		g.repoconfig.Features.ManageGithubAutolinks,
+		g.repoconfig.Features.ManageOrgCustomProperties,
+	)
+
 	// loading github assets can be long
 	err = g.remote.Load(ctx, false)
 	if err != nil {
@@ -348,6 +343,11 @@ func (g *GoliacImpl) Apply(ctx context.Context, logsCollector *observability.Log
 		g.cacheDirtyAfterAction = false
 
 		g.actionMutex.Unlock()
+		g.remote.SetFeatureFlags(
+			g.repoconfig.Features.ManageGithubEnvAndVariables,
+			g.repoconfig.Features.ManageGithubAutolinks,
+			g.repoconfig.Features.ManageOrgCustomProperties,
+		)
 		err = g.remote.Load(ctx, false)
 		if err != nil {
 			logsCollector.AddError(fmt.Errorf("error when loading data from Github: %v", err))
@@ -421,6 +421,15 @@ func (g *GoliacImpl) loadAndValidateGoliacOrganization(ctx context.Context, fs b
 			return
 		}
 		g.local.LoadAndValidateLocal(subfs, logsCollector)
+		if logsCollector.HasErrors() {
+			return
+		}
+		repoconfig := g.local.RepoConfig()
+		if repoconfig == nil {
+			logsCollector.AddError(fmt.Errorf("unable to read goliac.yaml config file"))
+			return
+		}
+		g.repoconfig = repoconfig
 	}
 
 	if logsCollector.HasErrors() {
@@ -602,8 +611,9 @@ func (g *GoliacImpl) applyCommitsToGithub(ctx context.Context, logsCollector *ob
 		remoteDataSource,
 		isEnterprise,
 		dryrun,
-		config.Config.ManageGithubActionsVariables,
-		config.Config.ManageGithubAutolinks,
+		g.repoconfig.Features.ManageGithubEnvAndVariables,
+		g.repoconfig.Features.ManageGithubAutolinks,
+		g.repoconfig.Features.ManageOrgCustomProperties,
 	)
 	if err != nil {
 		return unmanaged, fmt.Errorf("error when reconciliating: %v", err)

--- a/internal/goliac_test.go
+++ b/internal/goliac_test.go
@@ -605,6 +605,9 @@ func (m *GoliacRemoteExecutorMock) CountAssets(ctx context.Context, warmup bool)
 func (g *GoliacRemoteExecutorMock) SetRemoteObservability(feedback observability.RemoteObservability) {
 }
 
+func (e *GoliacRemoteExecutorMock) SetFeatureFlags(manageGithubVariables bool, manageGithubAutolinks bool, manageOrgCustomProperties bool) {
+}
+
 func (e *GoliacRemoteExecutorMock) AddUserToOrg(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, ghuserid string) {
 	fmt.Println("*** AddUserToOrg", ghuserid)
 	e.nbChanges++

--- a/internal/scaffold.go
+++ b/internal/scaffold.go
@@ -42,7 +42,7 @@ func NewScaffold() (*Scaffold, error) {
 		return nil, err
 	}
 
-	remote := engine.NewGoliacRemoteImpl(githubClient, config.Config.GithubAppOrganization, config.Config.ManageGithubActionsVariables, config.Config.ManageGithubAutolinks, config.Config.ManageOrgCustomProperties)
+	remote := engine.NewGoliacRemoteImpl(githubClient, config.Config.GithubAppOrganization, true, true, true)
 
 	loadUsersFromGithubOrgSaml := func(feedback observability.RemoteObservability) (map[string]*entity.User, error) {
 		ctx := context.Background()
@@ -719,6 +719,11 @@ func (s *Scaffold) generateGoliacConf(fs billy.Filesystem, rootpath string, admi
 
 	conf := fmt.Sprintf(`
 admin_team: %s
+
+features:
+  manage_github_env_and_variables: true
+  manage_github_autolinks: true
+  manage_org_custom_properties: true
 
 rulesets:
   - default

--- a/internal/scaffold_test.go
+++ b/internal/scaffold_test.go
@@ -64,6 +64,9 @@ func (m *ScaffoldGoliacRemoteMock) CountAssets(ctx context.Context, warmup bool)
 func (g *ScaffoldGoliacRemoteMock) SetRemoteObservability(feedback observability.RemoteObservability) {
 }
 
+func (s *ScaffoldGoliacRemoteMock) SetFeatureFlags(manageGithubVariables bool, manageGithubAutolinks bool, manageOrgCustomProperties bool) {
+}
+
 func (s *ScaffoldGoliacRemoteMock) EnvironmentSecretsPerRepository(ctx context.Context, environments []string, repositoryName string) (map[string]map[string]*engine.GithubVariable, error) {
 	return nil, nil
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk due to a **breaking configuration change** (env vars removed) and altered plan/apply load order that can change what GitHub assets are fetched/reconciled on first load; defaults remain `true` to preserve prior behavior when `features` is omitted.
> 
> **Overview**
> **Moves GitHub integration toggles from environment variables to `goliac.yaml`.** A new `features` block controls syncing GitHub Actions environments/variables, repository autolinks, and org custom properties (defaulting to `true` when omitted), and the old env vars are removed.
> 
> **Plan/apply now loads `goliac.yaml` before warming the GitHub remote cache** and pushes these flags into the remote via `SetFeatureFlags`, so the initial remote load and reconciliation honor the configured feature set. Org custom properties reconciliation is now gated by the new flag, and the reconciliator/remote interfaces + tests/scaffold output are updated accordingly; docs/quickstart also clarify PAT usage for ruleset integration issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb900d4a32072b6d267a1c48f77a5289ba2802de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->