### PR TITLE
V1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
+## Goliac v1.8.1
+
+- manage_org_custom_properties bugfix (it was not fully taken into account)
+
 ## Goliac v1.8.0
 
 - configure GitHub Actions environments/variables, repository autolinks, and organization custom properties via `goliac.yaml` under `features` instead of environment variables
 - **Breaking / migration:** remove `GOLIAC_MANAGE_GITHUB_ACTIONS_VARIABLES`, `GOLIAC_MANAGE_GITHUB_AUTOLINKS`, and `GOLIAC_MANAGE_ORG_CUSTOM_PROPERTIES` from your deployment; set `features.manage_github_env_and_variables`, `features.manage_github_autolinks`, and `features.manage_org_custom_properties` in `goliac.yaml`. If the `features` block is omitted, all three still default to `true` (same as the former env defaults)
 - plan/apply loads `goliac.yaml` before warming the GitHub remote cache so those flags apply to the first load
-0 update the documentation regarding Github ruleset integration issues
+- update the documentation regarding Github ruleset integration issues
 
 ## Goliac v1.7.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Goliac v1.8.2
+
+- bugfix: repository topics update no longer returns HTTP 422 when `topics` is omitted in the repository definition (send an empty JSON array instead of `null` for GitHub’s replace-topics API)
+
 ## Goliac v1.8.1
 
 - manage_org_custom_properties bugfix (it was not fully taken into account)

--- a/internal/engine/remote.go
+++ b/internal/engine/remote.go
@@ -4161,6 +4161,10 @@ func (g *GoliacRemoteImpl) UpdateRepositoryTopics(ctx context.Context, logsColle
 	}
 	g.actionMutex.Unlock()
 
+	if topics == nil {
+		topics = []string{}
+	}
+
 	if !dryrun {
 		body, err := g.client.CallRestAPI(
 			ctx,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk, small defensive change to always send an empty topics list to GitHub’s replace-topics API instead of `null`, plus a changelog entry.
> 
> **Overview**
> Fixes repository topic updates so that when `topics` is omitted, `UpdateRepositoryTopics` sends an empty array rather than `null`, avoiding GitHub HTTP 422 errors.
> 
> Updates `CHANGELOG.md` with the `v1.8.2` release note for this bugfix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa6b84f186da0636a5a749d0a2a72e00079b103d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->