### PR TITLE
V1 8 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Goliac v1.8.3
+- bugfix: validate correctly rulesets when the repository is not defined in the ruleset
+
 ## Goliac v1.8.2
 
 - bugfix: repository topics update no longer returns HTTP 422 when `topics` is omitted in the repository definition (send an empty JSON array instead of `null` for GitHub’s replace-topics API)

--- a/internal/engine/local.go
+++ b/internal/engine/local.go
@@ -960,9 +960,6 @@ func (g *GoliacLocalImpl) loadUsers(fs billy.Filesystem, LogCollection *observab
 	// Parse all the users in the <orgDirectory>/external-users directory
 	externalUsers := entity.ReadUserDirectory(fs, filepath.Join("users", "external"), LogCollection)
 	g.externalUsers = externalUsers
-
-	rulesets := entity.ReadRuleSetDirectory(fs, filepath.Join("rulesets"), LogCollection)
-	g.rulesets = rulesets
 }
 
 /**
@@ -992,7 +989,11 @@ func (g *GoliacLocalImpl) LoadAndValidateLocal(fs billy.Filesystem, LogCollectio
 	repos := entity.ReadRepositories(fs, "archived", "teams", g.teams, g.externalUsers, g.users, g.repoconfig.OrgCustomProperties, LogCollection)
 	g.repositories = repos
 
-	rulesets := entity.ReadRuleSetDirectory(fs, "rulesets", LogCollection)
+	repoNames := make([]string, 0, len(g.repositories))
+	for name := range g.repositories {
+		repoNames = append(repoNames, name)
+	}
+	rulesets := entity.ReadRuleSetDirectory(fs, "rulesets", repoNames, LogCollection)
 	g.rulesets = rulesets
 
 	workflows := entity.ReadWorkflowDirectory(fs, "workflows", LogCollection)

--- a/internal/entity/entity_ruleset.go
+++ b/internal/entity/entity_ruleset.go
@@ -175,7 +175,7 @@ type RuleSet struct {
 
 /*
  * NewRuleSet reads a file and returns a RuleSet object
- * The next step is to validate the RuleSet object using the Validate method
+ * The next step is to validate the RuleSet object using Validate (with known repository names when applicable).
  */
 func NewRuleSet(fs billy.Filesystem, filename string) (*RuleSet, error) {
 	filecontent, err := utils.ReadFile(fs, filename)
@@ -215,8 +215,11 @@ func NewRuleSet(fs billy.Filesystem, filename string) (*RuleSet, error) {
  * - a map of RuleSet objects
  * - a slice of errors that must stop the validation process
  * - a slice of warning that must not stop the validation process
+ *
+ * knownRepositories names all repositories defined in the org (e.g. keys from ReadRepositories).
+ * If non-nil, each ruleset must match at least one of them via BuildRepositoriesList. Pass nil to skip that check.
  */
-func ReadRuleSetDirectory(fs billy.Filesystem, dirname string, LogCollection *observability.LogCollection) map[string]*RuleSet {
+func ReadRuleSetDirectory(fs billy.Filesystem, dirname string, knownRepositories []string, LogCollection *observability.LogCollection) map[string]*RuleSet {
 	rulesets := make(map[string]*RuleSet)
 
 	exist, err := utils.Exists(fs, dirname)
@@ -247,7 +250,7 @@ func ReadRuleSetDirectory(fs billy.Filesystem, dirname string, LogCollection *ob
 		if err != nil {
 			LogCollection.AddError(err)
 		} else {
-			err := ruleset.Validate(filepath.Join(dirname, e.Name()))
+			err := ruleset.Validate(filepath.Join(dirname, e.Name()), knownRepositories)
 			if err != nil {
 				LogCollection.AddError(err)
 			} else {
@@ -317,7 +320,7 @@ func ValidateRulesetDefinition(r *RuleSetDefinition, filename string) error {
 	return nil
 }
 
-func (r *RuleSet) Validate(filename string) error {
+func (r *RuleSet) Validate(filename string, knownRepositories []string) error {
 
 	if r.ApiVersion != "v1" {
 		return fmt.Errorf("invalid apiVersion: %s for ruleset filename %s", r.ApiVersion, filename)
@@ -383,6 +386,16 @@ func (r *RuleSet) Validate(filename string) error {
 		_, err := regexp.Compile(fmt.Sprintf("^%s$", repo))
 		if err != nil {
 			return fmt.Errorf("error compiling regex %s: %v", repo, err)
+		}
+	}
+
+	if knownRepositories != nil {
+		matched, err := r.BuildRepositoriesList(knownRepositories)
+		if err != nil {
+			return err
+		}
+		if len(matched) == 0 {
+			return fmt.Errorf("spec.repositories must match at least one known repository for ruleset filename %s", filename)
 		}
 	}
 

--- a/internal/entity/entity_ruletset_test.go
+++ b/internal/entity/entity_ruletset_test.go
@@ -66,12 +66,40 @@ func TestRuleset(t *testing.T) {
 		fixtureCreateRuleSet(t, fs)
 
 		logsCollector := observability.NewLogCollection()
-		rulesets := ReadRuleSetDirectory(fs, "rulesets", logsCollector)
+		rulesets := ReadRuleSetDirectory(fs, "rulesets", nil, logsCollector)
 		assert.Equal(t, false, logsCollector.HasErrors())
 		assert.Equal(t, false, logsCollector.HasWarns())
 		assert.NotNil(t, rulesets)
 		assert.Equal(t, 2, len(rulesets))
 
+	})
+
+	t.Run("spec.repositories must match at least one known repository", func(t *testing.T) {
+		fs := memfs.New()
+		fs.MkdirAll("rulesets", 0755)
+		err := utils.WriteFile(fs, "rulesets/nomatch.yaml", []byte(`
+apiVersion: v1
+kind: Ruleset
+name: nomatch
+spec:
+  repositories:
+    included:
+      - "^only-this-name$"
+  ruleset:
+    enforcement: evaluate
+    conditions:
+      include:
+        - "~DEFAULT_BRANCH"
+    rules:
+      - ruletype: pull_request
+        parameters:
+          requiredApprovingReviewCount: 1
+`), 0644)
+		assert.Nil(t, err)
+
+		logsCollector := observability.NewLogCollection()
+		ReadRuleSetDirectory(fs, "rulesets", []string{"other-repo"}, logsCollector)
+		assert.True(t, logsCollector.HasErrors())
 	})
 }
 
@@ -84,7 +112,7 @@ func TestRulesetParametersComparison(t *testing.T) {
 		fixtureCreateRuleSet(t, fs)
 
 		logsCollector := observability.NewLogCollection()
-		rulesets := ReadRuleSetDirectory(fs, "rulesets", logsCollector)
+		rulesets := ReadRuleSetDirectory(fs, "rulesets", nil, logsCollector)
 		assert.Equal(t, false, logsCollector.HasErrors())
 		assert.Equal(t, false, logsCollector.HasWarns())
 		assert.NotNil(t, rulesets)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Tightens ruleset validation during local load, which can cause previously-accepted ruleset files to fail validation if their `spec.repositories` patterns match no repositories. Impact is limited to ruleset parsing/validation but may break existing configs at runtime.
> 
> **Overview**
> **Ruleset validation now checks repository targeting against the org’s known repositories.** `LoadAndValidateLocal` collects repository names and passes them into `ReadRuleSetDirectory`, and `RuleSet.Validate` errors if `spec.repositories` matches zero repos (when known repo names are provided).
> 
> Tests are updated to pass `nil` when skipping this check and add coverage for the new validation failure case, and the changelog notes the v1.8.3 bugfix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba32cad30e740e1e398f694351eade7871401b4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->