### PR TITLE
V1.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
+## Goliac v1.8.4
+
+- validation improvement: validate ruleset repositories presence
+- bugfix: do not reorder CODEOWNERS
+
 ## Goliac v1.8.3
+
 - bugfix: validate correctly rulesets when the repository is not defined in the ruleset
 
 ## Goliac v1.8.2

--- a/internal/entity/repository.go
+++ b/internal/entity/repository.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strings"
 
 	"github.com/go-git/go-billy/v5"
@@ -460,26 +459,13 @@ func (r *Repository) Validate(filename string, teams map[string]*Team, externalU
 	return nil
 }
 
-// codeownersPatternField returns the first field of a CODEOWNERS rule line (the path/pattern).
-// Comment and empty lines yield an empty string.
-func codeownersPatternField(line string) string {
-	line = strings.TrimSpace(line)
-	if line == "" || strings.HasPrefix(line, "#") {
-		return ""
-	}
-	fields := strings.Fields(line)
-	if len(fields) == 0 {
-		return ""
-	}
-	return fields[0]
-}
-
 // GenerateCodeownersContent generates the CODEOWNERS file content from structured spec.codeowners
 // and/or codeowners_raw. Team names in structured entries resolve to @org/team-slug.
 // Structured and raw rule lines are merged; comment lines from raw (lines whose trimmed content
-// starts with #) are emitted after the Goliac header and before rule lines. Rule lines are sorted
-// by ascending length of the path/pattern (first field), stable for ties. codeowners_raw rule lines
-// are not validated.
+// starts with #) are emitted after the Goliac header and before rule lines. Rule line order is
+// preserved: all structured entries in YAML order, then all codeowners_raw rule lines in source
+// order. This matches GitHub semantics where the last matching pattern wins — authors must order
+// rules accordingly. codeowners_raw rule lines are not validated.
 // Returns empty string if neither codeowners nor codeowners_raw are defined.
 func (r *Repository) GenerateCodeownersContent(githubOrganization string) string {
 	hasStructured := len(r.Spec.Codeowners) > 0
@@ -520,12 +506,6 @@ func (r *Repository) GenerateCodeownersContent(githubOrganization string) string
 			}
 		}
 	}
-
-	sort.SliceStable(ruleLines, func(i, j int) bool {
-		pi := codeownersPatternField(ruleLines[i])
-		pj := codeownersPatternField(ruleLines[j])
-		return len(pi) < len(pj)
-	})
 
 	var sb strings.Builder
 	sb.WriteString("# DO NOT MODIFY THIS FILE MANUALLY\n")

--- a/internal/entity/repository_test.go
+++ b/internal/entity/repository_test.go
@@ -383,8 +383,8 @@ func TestGenerateCodeownersContent(t *testing.T) {
 		repo := &Repository{}
 		repo.Spec.CodeownersRaw = "/vendor/ @external-user\n/docs/ @myorg/docs-team"
 		content := repo.GenerateCodeownersContent("myorg")
-		// sorted by pattern length: /docs/ (7) < /vendor/ (9)
-		expected := "# DO NOT MODIFY THIS FILE MANUALLY\n# This file is managed by Goliac\n\n/docs/ @myorg/docs-team\n/vendor/ @external-user\n"
+		// preserves codeowners_raw source order
+		expected := "# DO NOT MODIFY THIS FILE MANUALLY\n# This file is managed by Goliac\n\n/vendor/ @external-user\n/docs/ @myorg/docs-team\n"
 		assert.Equal(t, expected, content)
 	})
 
@@ -392,23 +392,23 @@ func TestGenerateCodeownersContent(t *testing.T) {
 		repo := &Repository{}
 		repo.Spec.Codeowners = []RepositoryCodeownersEntry{
 			{Pattern: "*", Owners: []string{"sre"}},
-			{Pattern: "ac-live-data/", Owners: []string{"data-team"}},
+			{Pattern: "services/api/", Owners: []string{"api-team"}},
 		}
 		repo.Spec.CodeownersRaw = "/vendor/ @external-user"
 		content := repo.GenerateCodeownersContent("myorg")
-		// merged then sorted: * (1), /vendor/ (9), ac-live-data/ (13)
-		expected := "# DO NOT MODIFY THIS FILE MANUALLY\n# This file is managed by Goliac\n\n* @myorg/sre\n/vendor/ @external-user\nac-live-data/ @myorg/data-team\n"
+		// structured entries first (YAML order), then raw rule lines in source order
+		expected := "# DO NOT MODIFY THIS FILE MANUALLY\n# This file is managed by Goliac\n\n* @myorg/sre\nservices/api/ @myorg/api-team\n/vendor/ @external-user\n"
 		assert.Equal(t, expected, content)
 	})
 
-	t.Run("sorts merged rules by pattern length", func(t *testing.T) {
+	t.Run("preserves structured then raw rule order", func(t *testing.T) {
 		repo := &Repository{}
 		repo.Spec.Codeowners = []RepositoryCodeownersEntry{
 			{Pattern: "/zz/long/", Owners: []string{"a"}},
 		}
 		repo.Spec.CodeownersRaw = "* @x\n/foo/ @y"
 		content := repo.GenerateCodeownersContent("myorg")
-		expected := "# DO NOT MODIFY THIS FILE MANUALLY\n# This file is managed by Goliac\n\n* @x\n/foo/ @y\n/zz/long/ @myorg/a\n"
+		expected := "# DO NOT MODIFY THIS FILE MANUALLY\n# This file is managed by Goliac\n\n/zz/long/ @myorg/a\n* @x\n/foo/ @y\n"
 		assert.Equal(t, expected, content)
 	})
 
@@ -419,7 +419,8 @@ func TestGenerateCodeownersContent(t *testing.T) {
 /long/path/ @a
 * @b`
 		content := repo.GenerateCodeownersContent("myorg")
-		expected := "# DO NOT MODIFY THIS FILE MANUALLY\n# This file is managed by Goliac\n\n# not a rule\n# second comment\n\n* @b\n/long/path/ @a\n"
+		// rule lines keep codeowners_raw order (GitHub: last match wins — authors order rules accordingly)
+		expected := "# DO NOT MODIFY THIS FILE MANUALLY\n# This file is managed by Goliac\n\n# not a rule\n# second comment\n\n/long/path/ @a\n* @b\n"
 		assert.Equal(t, expected, content)
 	})
 
@@ -604,8 +605,8 @@ kind: Repository
 name: repo1
 spec:
   codeowners_raw: |
-    * @AlayaCare/team-badwolf
-    ac-live-data/ @AlayaCare/team-sphinx
+    * @example-org/platform-team
+    infra/data/ @example-org/data-team
 `), 0644)
 		assert.Nil(t, err)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changing CODEOWNERS rule ordering can alter which owners are selected for overlapping patterns, potentially impacting review/ownership behavior across repositories.
> 
> **Overview**
> Updates `Repository.GenerateCodeownersContent` to **stop sorting** merged CODEOWNERS rules and instead preserve author-defined order (structured `spec.codeowners` in YAML order, followed by `codeowners_raw` in source order), aligning with GitHub’s *last match wins* behavior.
> 
> Adjusts CODEOWNERS-related tests to assert the new ordering semantics, and updates `CHANGELOG.md` for `v1.8.4` to note the CODEOWNERS reordering bugfix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74a2b271e2ae17a20533e7626edbf14eaf38919e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->