### PR TITLE
V1.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Goliac v1.8.5
+
+- improvement: add Goliac app on repositories branch protection bypass when the repository is part of a workflow
+
 ## Goliac v1.8.4
 
 - validation improvement: validate ruleset repositories presence

--- a/internal/engine/goliac_reconciliator_datasource.go
+++ b/internal/engine/goliac_reconciliator_datasource.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/goliac-project/goliac/internal/config"
 	"github.com/goliac-project/goliac/internal/entity"
@@ -18,12 +19,17 @@ type GoliacReconciliatorDatasource interface {
 	OrgCustomProperties(ctx context.Context) map[string]*config.GithubCustomProperty
 }
 
+// githubWorkflowAppBypassMode is the ruleset bypass mode for the Goliac app when
+// auto-injected for workflow-scoped repositories (GitHub API: pull_request).
+const githubWorkflowAppBypassMode = "pull_request"
+
 type GoliacReconciliatorDatasourceLocal struct {
 	local               GoliacLocal
 	conf                *config.RepositoryConfig
 	teamsreponame       string
 	teamsDefaultBranch  string
 	reconciliatorFilter *ReconciliatorFilterImpl
+	githubAppSlug       string
 }
 
 func NewGoliacReconciliatorDatasourceLocal(
@@ -31,13 +37,16 @@ func NewGoliacReconciliatorDatasourceLocal(
 	teamsreponame string,
 	teamsDefaultBranch string,
 	isEnterprise bool,
-	conf *config.RepositoryConfig) GoliacReconciliatorDatasource {
+	conf *config.RepositoryConfig,
+	githubAppSlug string,
+) GoliacReconciliatorDatasource {
 	return &GoliacReconciliatorDatasourceLocal{
 		local:               local,
 		conf:                conf,
 		teamsreponame:       teamsreponame,
 		teamsDefaultBranch:  teamsDefaultBranch,
 		reconciliatorFilter: NewReconciliatorFilter(isEnterprise, conf),
+		githubAppSlug:       githubAppSlug,
 	}
 }
 
@@ -293,6 +302,15 @@ func (d *GoliacReconciliatorDatasourceLocal) Repositories() (map[string]*GithubR
 			branchprotections[bp.Pattern] = &branchprotection
 		}
 
+		if d.githubAppSlug != "" && (len(branchprotections) > 0 || len(rulesets) > 0) && d.local.RepositoryInWorkflow(reponame) {
+			for _, bp := range branchprotections {
+				ensureGoliacAppBypassOnBranchProtection(bp, d.githubAppSlug)
+			}
+			for _, rs := range rulesets {
+				ensureGoliacAppBypassOnRuleset(rs, d.githubAppSlug)
+			}
+		}
+
 		environments := make(map[string]*GithubEnvironment)
 		for _, e := range lRepo.Spec.Environments {
 			environments[e.Name] = &GithubEnvironment{
@@ -413,9 +431,70 @@ func (d *GoliacReconciliatorDatasourceLocal) RuleSets() (map[string]*GithubRuleS
 		}
 		grs.Repositories = nonArchivedRepositories
 
+		if d.shouldInjectGoliacBypassOnOrgRuleset(&grs, nonArchivedRepositories) {
+			ensureGoliacAppBypassOnRuleset(&grs, d.githubAppSlug)
+		}
+
 		lgrs[rs.Name] = &grs
 	}
 	return lgrs, nil
+}
+
+func (d *GoliacReconciliatorDatasourceLocal) shouldInjectGoliacBypassOnOrgRuleset(grs *GithubRuleSet, nonArchivedRepositories []string) bool {
+	if d.githubAppSlug == "" || grs == nil {
+		return false
+	}
+	if len(grs.Rules) == 0 || strings.EqualFold(grs.Enforcement, "disabled") {
+		return false
+	}
+	for _, reponame := range nonArchivedRepositories {
+		if d.local.RepositoryInWorkflow(reponame) {
+			return true
+		}
+	}
+	return false
+}
+
+func branchProtectionHasAppBypass(bp *GithubBranchProtection, appSlug string) bool {
+	want := slug.Make(appSlug)
+	for _, n := range bp.BypassPullRequestAllowances.Nodes {
+		if n.Actor.AppSlug != "" && slug.Make(n.Actor.AppSlug) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func ensureGoliacAppBypassOnBranchProtection(bp *GithubBranchProtection, appSlug string) {
+	if appSlug == "" || branchProtectionHasAppBypass(bp, appSlug) {
+		return
+	}
+	node := BypassPullRequestAllowanceNode{}
+	node.Actor.AppSlug = appSlug
+	bp.BypassPullRequestAllowances.Nodes = append(bp.BypassPullRequestAllowances.Nodes, node)
+}
+
+func rulesetHasAppBypass(rs *GithubRuleSet, appSlug string) bool {
+	if rs == nil || rs.BypassApps == nil {
+		return false
+	}
+	want := slug.Make(appSlug)
+	for k := range rs.BypassApps {
+		if slug.Make(k) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func ensureGoliacAppBypassOnRuleset(rs *GithubRuleSet, appSlug string) {
+	if appSlug == "" || rulesetHasAppBypass(rs, appSlug) {
+		return
+	}
+	if rs.BypassApps == nil {
+		rs.BypassApps = map[string]string{}
+	}
+	rs.BypassApps[appSlug] = githubWorkflowAppBypassMode
 }
 
 func (d *GoliacReconciliatorDatasourceLocal) OrgCustomProperties(ctx context.Context) map[string]*config.GithubCustomProperty {

--- a/internal/engine/goliac_reconciliator_datasource_test.go
+++ b/internal/engine/goliac_reconciliator_datasource_test.go
@@ -1,0 +1,114 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/goliac-project/goliac/internal/config"
+	"github.com/goliac-project/goliac/internal/entity"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGoliacReconciliatorDatasourceLocalWorkflowBypassInjection(t *testing.T) {
+	wf := &entity.Workflow{}
+	wf.Spec.Repositories.Allowed = []string{"myrepo"}
+
+	local := &GoliacLocalImpl{
+		teams:         map[string]*entity.Team{},
+		repositories:  map[string]*entity.Repository{},
+		users:         map[string]*entity.User{},
+		externalUsers: map[string]*entity.User{},
+		rulesets:      map[string]*entity.RuleSet{},
+		workflows:     map[string]*entity.Workflow{"w": wf},
+		repoconfig:    &config.RepositoryConfig{},
+	}
+
+	repo := &entity.Repository{}
+	repo.Spec.BranchProtections = []entity.RepositoryBranchProtection{
+		{Pattern: "main", RequiresApprovingReviews: true},
+	}
+	local.repositories["myrepo"] = repo
+
+	repoconf := &config.RepositoryConfig{AdminTeam: "admin"}
+	d := NewGoliacReconciliatorDatasourceLocal(local, "teams", "main", true, repoconf, "goliac-app")
+
+	repos, _, err := d.Repositories()
+	assert.NoError(t, err)
+	r := repos["myrepo"]
+	bp := r.BranchProtections["main"]
+	found := false
+	for _, n := range bp.BypassPullRequestAllowances.Nodes {
+		if n.Actor.AppSlug == "goliac-app" {
+			found = true
+		}
+	}
+	assert.True(t, found, "Goliac app should be injected as bypass on branch protection")
+}
+
+func TestGoliacReconciliatorDatasourceLocalWorkflowBypassNoDuplicate(t *testing.T) {
+	wf := &entity.Workflow{}
+	wf.Spec.Repositories.Allowed = []string{"myrepo"}
+
+	local := &GoliacLocalImpl{
+		teams:         map[string]*entity.Team{},
+		repositories:  map[string]*entity.Repository{},
+		users:         map[string]*entity.User{},
+		externalUsers: map[string]*entity.User{},
+		rulesets:      map[string]*entity.RuleSet{},
+		workflows:     map[string]*entity.Workflow{"w": wf},
+		repoconfig:    &config.RepositoryConfig{},
+	}
+
+	repo := &entity.Repository{}
+	repo.Spec.BranchProtections = []entity.RepositoryBranchProtection{
+		{
+			Pattern:                  "main",
+			RequiresApprovingReviews: true,
+			BypassPullRequestApps:    []string{"goliac-app"},
+		},
+	}
+	local.repositories["myrepo"] = repo
+
+	repoconf := &config.RepositoryConfig{AdminTeam: "admin"}
+	d := NewGoliacReconciliatorDatasourceLocal(local, "teams", "main", true, repoconf, "goliac-app")
+
+	repos, _, err := d.Repositories()
+	assert.NoError(t, err)
+	r := repos["myrepo"]
+	bp := r.BranchProtections["main"]
+	count := 0
+	for _, n := range bp.BypassPullRequestAllowances.Nodes {
+		if n.Actor.AppSlug == "goliac-app" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count)
+}
+
+func TestGoliacReconciliatorDatasourceLocalShouldInjectOrgRuleset(t *testing.T) {
+	wf := &entity.Workflow{}
+	wf.Spec.Repositories.Allowed = []string{"target-repo"}
+
+	local := &GoliacLocalImpl{
+		teams:         map[string]*entity.Team{},
+		repositories:  map[string]*entity.Repository{},
+		users:         map[string]*entity.User{},
+		externalUsers: map[string]*entity.User{},
+		rulesets:      map[string]*entity.RuleSet{},
+		workflows:     map[string]*entity.Workflow{"w": wf},
+		repoconfig:    &config.RepositoryConfig{},
+	}
+
+	repoconf := &config.RepositoryConfig{AdminTeam: "admin"}
+	dl := NewGoliacReconciliatorDatasourceLocal(local, "teams", "main", true, repoconf, "goliac-app").(*GoliacReconciliatorDatasourceLocal)
+
+	grs := &GithubRuleSet{
+		Enforcement: "active",
+		Rules: map[string]entity.RuleSetParameters{
+			"pull_request": {},
+		},
+	}
+	assert.True(t, dl.shouldInjectGoliacBypassOnOrgRuleset(grs, []string{"target-repo"}))
+	assert.False(t, dl.shouldInjectGoliacBypassOnOrgRuleset(grs, []string{"other-repo"}))
+	assert.False(t, dl.shouldInjectGoliacBypassOnOrgRuleset(&GithubRuleSet{Enforcement: "active", Rules: nil}, []string{"target-repo"}))
+	assert.False(t, dl.shouldInjectGoliacBypassOnOrgRuleset(&GithubRuleSet{Enforcement: "disabled", Rules: map[string]entity.RuleSetParameters{"pull_request": {}}}, []string{"target-repo"}))
+}

--- a/internal/engine/goliac_reconciliator_test.go
+++ b/internal/engine/goliac_reconciliator_test.go
@@ -65,6 +65,11 @@ func (m *GoliacLocalMock) RuleSets() map[string]*entity.RuleSet {
 func (m *GoliacLocalMock) Workflows() map[string]*entity.Workflow {
 	return m.workflows
 }
+
+func (m *GoliacLocalMock) RepositoryInWorkflow(repository string) bool {
+	return false
+}
+
 func (m *GoliacLocalMock) UpdateAndCommitCodeOwners(ctx context.Context, repoconfig *config.RepositoryConfig, dryrun bool, accesstoken string, branch string, tagname string, githubOrganization string) error {
 	return nil
 }
@@ -489,7 +494,7 @@ func TestReconciliationTeam(t *testing.T) {
 			appids:     make(map[string]*GithubApp),
 		}
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		lTeams, _, _ := localDatasource.Teams()
@@ -542,7 +547,7 @@ func TestReconciliationTeam(t *testing.T) {
 			appids:     make(map[string]*GithubApp),
 		}
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -608,7 +613,7 @@ func TestReconciliationTeam(t *testing.T) {
 		}
 		remote.teams["existing"+config.Config.GoliacTeamOwnerSuffix] = existingowners
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -675,7 +680,7 @@ func TestReconciliationTeam(t *testing.T) {
 		}
 		remote.teams["exist-ing"+config.Config.GoliacTeamOwnerSuffix] = existingowners
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -727,7 +732,7 @@ func TestReconciliationTeam(t *testing.T) {
 			appids:     make(map[string]*GithubApp),
 		}
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -769,7 +774,7 @@ func TestReconciliationTeam(t *testing.T) {
 		}
 		remote.teams["removing"] = removing
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -847,7 +852,7 @@ func TestReconciliationTeam(t *testing.T) {
 		remote.teams["childteam"] = childTeam
 		remote.teams["childteam"+config.Config.GoliacTeamOwnerSuffix] = childTeamOwners
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -929,7 +934,7 @@ func TestReconciliationTeam(t *testing.T) {
 		remote.teams["childteam"] = childTeam
 		remote.teams["childteam"+config.Config.GoliacTeamOwnerSuffix] = childTeamOwners
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -1043,7 +1048,7 @@ func TestReconciliationTeam(t *testing.T) {
 		remote.teams["grandchildteam"] = grandChildTeam
 		remote.teams["grandchildteam"+config.Config.GoliacTeamOwnerSuffix] = grandChildTeamOwners
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -1080,7 +1085,7 @@ func TestReconciliationTeam(t *testing.T) {
 		}
 		remote.teams["removing"] = removing
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -1126,7 +1131,7 @@ func TestReconciliationRepo(t *testing.T) {
 			RepositoryVariables: NewMockMappedEntityLazyLoader[string](map[string]string{}),
 		}
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -1185,7 +1190,7 @@ func TestReconciliationRepo(t *testing.T) {
 		}
 		remote.teams["existing"] = existing
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -1254,7 +1259,7 @@ func TestReconciliationRepo(t *testing.T) {
 			Permission: "READ",
 		}
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -1329,7 +1334,7 @@ func TestReconciliationRepo(t *testing.T) {
 			Permission: "WRITE",
 		}
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -1415,7 +1420,7 @@ func TestReconciliationRepo(t *testing.T) {
 			Permission: "ADMIN",
 		}
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -1505,7 +1510,7 @@ func TestReconciliationRepo(t *testing.T) {
 			Permission: "WRITE",
 		}
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -1584,7 +1589,7 @@ func TestReconciliationRepo(t *testing.T) {
 			Permission: "WRITE",
 		}
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -1672,7 +1677,7 @@ func TestReconciliationRepo(t *testing.T) {
 			Permission: "WRITE",
 		}
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -1763,7 +1768,7 @@ func TestReconciliationRepo(t *testing.T) {
 			Permission: "WRITE",
 		}
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -1846,7 +1851,7 @@ func TestReconciliationRepo(t *testing.T) {
 			Permission: "WRITE",
 		}
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -1926,7 +1931,7 @@ func TestReconciliationRepo(t *testing.T) {
 			Permission: "WRITE",
 		}
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -2003,7 +2008,7 @@ func TestReconciliationRepo(t *testing.T) {
 			Permission: "WRITE",
 		}
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -2083,7 +2088,7 @@ func TestReconciliationRepo(t *testing.T) {
 			Permission: "WRITE",
 		}
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -2162,7 +2167,7 @@ func TestReconciliationRepo(t *testing.T) {
 			Permission: "WRITE",
 		}
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -2247,7 +2252,7 @@ func TestReconciliationRepo(t *testing.T) {
 			Permission: "WRITE",
 		}
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -2291,7 +2296,7 @@ func TestReconciliationRepo(t *testing.T) {
 		}
 		remote.repos["removing"] = removing
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -2331,7 +2336,7 @@ func TestReconciliationRepo(t *testing.T) {
 		}
 		remote.repos["removing"] = removing
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -2372,7 +2377,7 @@ func TestReconciliationRepo(t *testing.T) {
 		}
 		remote.repos["removing"] = removing
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -2514,7 +2519,7 @@ func TestReconciliationRepo(t *testing.T) {
 			Permission: "WRITE",
 		}
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "goliac-teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "goliac-teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -2663,7 +2668,7 @@ func TestReconciliationRepo(t *testing.T) {
 			Permission: "WRITE",
 		}
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "goliac-teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "goliac-teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -2719,7 +2724,7 @@ func TestReconciliationRulesets(t *testing.T) {
 			appids:     make(map[string]*GithubApp),
 		}
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -2768,7 +2773,7 @@ func TestReconciliationRulesets(t *testing.T) {
 			appids:     make(map[string]*GithubApp),
 		}
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -2825,7 +2830,7 @@ func TestReconciliationRulesets(t *testing.T) {
 		rRuleset.Rules["required_signatures"] = entity.RuleSetParameters{}
 		remote.rulesets["update"] = rRuleset
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -2872,7 +2877,7 @@ func TestReconciliationRulesets(t *testing.T) {
 		rRuleset.Rules["required_signatures"] = entity.RuleSetParameters{}
 		remote.rulesets["delete"] = rRuleset
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -2941,7 +2946,7 @@ func TestReconciliationRulesets(t *testing.T) {
 		rRuleset.BypassTeams["ateam"] = "pull_request"
 		remote.rulesets["new"] = rRuleset
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -3047,7 +3052,7 @@ func TestReconciliationRepoRulesets(t *testing.T) {
 
 		remote.repos["myrepo"] = myrepo
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -3137,7 +3142,7 @@ func TestReconciliationRepoRulesets(t *testing.T) {
 
 		remote.repos["myrepo"] = myrepo
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -3229,7 +3234,7 @@ func TestReconciliationRepoBranchProtection(t *testing.T) {
 
 		remote.repos["myrepo"] = myrepo
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -3313,7 +3318,7 @@ func TestReconciliationRepoBranchProtection(t *testing.T) {
 
 		remote.repos["myrepo"] = myrepo
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -3371,7 +3376,7 @@ func TestReconciliationRepositoryEnvironments(t *testing.T) {
 		}
 		remote.repos["test-repo"] = remoteRepo
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -3426,7 +3431,7 @@ func TestReconciliationRepositoryEnvironments(t *testing.T) {
 		}
 		remote.repos["test-repo"] = remoteRepo
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -3488,7 +3493,7 @@ func TestReconciliationRepositoryEnvironments(t *testing.T) {
 		}
 		remote.repos["test-repo"] = remoteRepo
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -3545,7 +3550,7 @@ func TestReconciliationAutolinks(t *testing.T) {
 		}
 		remote.repos["test-repo"] = remoteRepo
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -3600,7 +3605,7 @@ func TestReconciliationAutolinks(t *testing.T) {
 		}
 		remote.repos["test-repo"] = remoteRepo
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -3656,7 +3661,7 @@ func TestReconciliationAutolinks(t *testing.T) {
 		}
 		remote.repos["test-repo"] = remoteRepo
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -3709,7 +3714,7 @@ func TestReconciliationCustomProperties(t *testing.T) {
 			appids:     make(map[string]*GithubApp),
 		}
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -3775,7 +3780,7 @@ func TestReconciliationCustomProperties(t *testing.T) {
 			},
 		}
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -3821,7 +3826,7 @@ func TestReconciliationCustomProperties(t *testing.T) {
 			},
 		}
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -3870,7 +3875,7 @@ func TestReconciliationCustomProperties(t *testing.T) {
 			},
 		}
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()
@@ -3921,7 +3926,7 @@ func TestReconciliationCustomProperties(t *testing.T) {
 			appids:     make(map[string]*GithubApp),
 		}
 
-		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf)
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "teams", "main", true, &repoconf, "")
 		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
 
 		logsCollector := observability.NewLogCollection()

--- a/internal/engine/local.go
+++ b/internal/engine/local.go
@@ -73,6 +73,8 @@ type GoliacLocalResources interface {
 	ExternalUsers() map[string]*entity.User
 	RuleSets() map[string]*entity.RuleSet   //global rulesets
 	Workflows() map[string]*entity.Workflow // global workflows
+	// RepositoryInWorkflow is true if the repository matches at least one loaded workflow's repository scope.
+	RepositoryInWorkflow(repository string) bool
 	RepoConfig() *config.RepositoryConfig
 }
 
@@ -135,6 +137,20 @@ func (g *GoliacLocalImpl) RuleSets() map[string]*entity.RuleSet {
 func (g *GoliacLocalImpl) Workflows() map[string]*entity.Workflow {
 	return g.workflows
 }
+
+func (g *GoliacLocalImpl) RepositoryInWorkflow(repository string) bool {
+	for _, w := range g.workflows {
+		ok, err := w.AppliesToRepository(repository)
+		if err != nil {
+			continue
+		}
+		if ok {
+			return true
+		}
+	}
+	return false
+}
+
 func (g *GoliacLocalImpl) RepoConfig() *config.RepositoryConfig {
 	return g.repoconfig
 }

--- a/internal/engine/local_test.go
+++ b/internal/engine/local_test.go
@@ -908,6 +908,17 @@ func TestGoliacLocalImpl(t *testing.T) {
 	})
 }
 
+func TestGoliacLocalImplRepositoryInWorkflow(t *testing.T) {
+	w := &entity.Workflow{}
+	w.Spec.Repositories.Allowed = []string{"svc-.*"}
+
+	g := &GoliacLocalImpl{
+		workflows: map[string]*entity.Workflow{"fm": w},
+	}
+	assert.True(t, g.RepositoryInWorkflow("svc-api"))
+	assert.False(t, g.RepositoryInWorkflow("other"))
+}
+
 type UserSyncPluginMock struct {
 }
 

--- a/internal/entity/workflow.go
+++ b/internal/entity/workflow.go
@@ -3,6 +3,7 @@ package entity
 import (
 	"fmt"
 	"path/filepath"
+	"regexp"
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/goliac-project/goliac/internal/config"
@@ -134,6 +135,41 @@ func (w *Workflow) Validate(filename string) error {
 	}
 
 	return nil
+}
+
+// AppliesToRepository returns whether the repository name matches this workflow's
+// spec.repositories allowed/except rules (same semantics as the repository check in workflow ACL).
+func (w *Workflow) AppliesToRepository(repository string) (bool, error) {
+	repoMatch := false
+	for _, repo := range w.Spec.Repositories.Allowed {
+		if repo == "~ALL" {
+			repoMatch = true
+			break
+		}
+		repoRegex, err := regexp.Match(fmt.Sprintf("^%s$", repo), []byte(repository))
+		if err != nil {
+			return false, err
+		}
+		if repoRegex {
+			repoMatch = true
+			break
+		}
+	}
+
+	for _, repo := range w.Spec.Repositories.Except {
+		repoRegex, err := regexp.Match(fmt.Sprintf("^%s$", repo), []byte(repository))
+		if err != nil {
+			return false, err
+		}
+		if repoRegex {
+			return false, nil
+		}
+	}
+
+	if !repoMatch {
+		return false, nil
+	}
+	return true, nil
 }
 
 func ReadWorkflowDirectory(fs billy.Filesystem, dirname string, LogCollection *observability.LogCollection) map[string]*Workflow {

--- a/internal/entity/workflow_test.go
+++ b/internal/entity/workflow_test.go
@@ -106,3 +106,35 @@ spec:
 	})
 
 }
+
+func TestWorkflowAppliesToRepository(t *testing.T) {
+	t.Run("tilde all", func(t *testing.T) {
+		w := &Workflow{}
+		w.Spec.Repositories.Allowed = []string{"~ALL"}
+		ok, err := w.AppliesToRepository("any-repo")
+		assert.NoError(t, err)
+		assert.True(t, ok)
+	})
+	t.Run("exact allow", func(t *testing.T) {
+		w := &Workflow{}
+		w.Spec.Repositories.Allowed = []string{"my-repo"}
+		ok, err := w.AppliesToRepository("my-repo")
+		assert.NoError(t, err)
+		assert.True(t, ok)
+	})
+	t.Run("except excludes", func(t *testing.T) {
+		w := &Workflow{}
+		w.Spec.Repositories.Allowed = []string{"~ALL"}
+		w.Spec.Repositories.Except = []string{"excluded"}
+		ok, err := w.AppliesToRepository("excluded")
+		assert.NoError(t, err)
+		assert.False(t, ok)
+	})
+	t.Run("no allow match", func(t *testing.T) {
+		w := &Workflow{}
+		w.Spec.Repositories.Allowed = []string{"other"}
+		ok, err := w.AppliesToRepository("mine")
+		assert.NoError(t, err)
+		assert.False(t, ok)
+	})
+}

--- a/internal/goliac.go
+++ b/internal/goliac.go
@@ -602,7 +602,7 @@ func (g *GoliacImpl) applyCommitsToGithub(ctx context.Context, logsCollector *ob
 	// the repo has already been cloned (to HEAD) and validated (see loadAndValidateGoliacOrganization)
 	// we can now apply the changes to the github team repository
 	isEnterprise := g.remote.IsEnterprise()
-	localDatasource := engine.NewGoliacReconciliatorDatasourceLocal(g.local, teamreponame, branch, isEnterprise, g.repoconfig)
+	localDatasource := engine.NewGoliacReconciliatorDatasourceLocal(g.local, teamreponame, branch, isEnterprise, g.repoconfig, g.localGithubClient.GetAppSlug())
 	remoteDataSource := engine.NewGoliacReconciliatorDatasourceRemote(g.remote)
 	unmanaged, reposToArchive, renameTo, err := reconciliator.Reconciliate(
 		ctx,

--- a/internal/goliac_server_test.go
+++ b/internal/goliac_server_test.go
@@ -46,6 +46,11 @@ func (g *GoliacLocalMock) RuleSets() map[string]*entity.RuleSet {
 func (g *GoliacLocalMock) Workflows() map[string]*entity.Workflow {
 	return g.workflows
 }
+
+func (g *GoliacLocalMock) RepositoryInWorkflow(repository string) bool {
+	return false
+}
+
 func (g *GoliacLocalMock) RepoConfig() *config.RepositoryConfig {
 	return g.repoconfig
 }

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -33,6 +33,8 @@ type WorkflowLocalResource interface {
 	Workflows() map[string]*entity.Workflow
 	Teams() map[string]*entity.Team
 	Users() map[string]*entity.User // github username, user definition
+	// RepositoryInWorkflow is true if the repository matches at least one loaded workflow's repository scope.
+	RepositoryInWorkflow(repository string) bool
 }
 
 // strip down version of Goliac Remote (if we have an externally managed team)
@@ -167,33 +169,10 @@ func (ws *WorkflowServiceImpl) GetWorkflow(ctx context.Context, repoconfigForceM
 }
 
 func (ws *WorkflowServiceImpl) passAcl(w *entity.Workflow, username string, usernameTeams []string, repository string) (bool, error) {
-	// checking the repository name
-	repoMatch := false
-	for _, repo := range w.Spec.Repositories.Allowed {
-		if repo == "~ALL" {
-			repoMatch = true
-			break
-		}
-		repoRegex, err := regexp.Match(fmt.Sprintf("^%s$", repo), []byte(repository))
-		if err != nil {
-			return false, err
-		}
-		if repoRegex {
-			repoMatch = true
-			break
-		}
+	repoMatch, err := w.AppliesToRepository(repository)
+	if err != nil {
+		return false, err
 	}
-
-	for _, repo := range w.Spec.Repositories.Except {
-		repoRegex, err := regexp.Match(fmt.Sprintf("^%s$", repo), []byte(repository))
-		if err != nil {
-			return false, err
-		}
-		if repoRegex {
-			return false, nil
-		}
-	}
-
 	if !repoMatch {
 		return false, nil
 	}

--- a/internal/workflow/workflow_test.go
+++ b/internal/workflow/workflow_test.go
@@ -18,6 +18,11 @@ type LocalResourceMock struct {
 func (m *LocalResourceMock) Workflows() map[string]*entity.Workflow {
 	return m.MockWorkflows
 }
+
+func (m *LocalResourceMock) RepositoryInWorkflow(repository string) bool {
+	return false
+}
+
 func (m *LocalResourceMock) Teams() map[string]*entity.Team {
 	return m.LTeams
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adjusts branch protection and ruleset bypass actors by automatically adding the Goliac GitHub App for repositories included in workflows, which can affect enforcement/security behavior if mis-scoped.
> 
> **Overview**
> Adds automatic injection of the Goliac GitHub App as a bypass actor on *repository branch protections* and *rulesets* when the repository is in the scope of at least one workflow (using bypass mode `pull_request`).
> 
> Introduces workflow repository matching helpers (`Workflow.AppliesToRepository`, `GoliacLocal.RepositoryInWorkflow`) and updates the reconciliator datasource to accept an app slug (wired from `localGithubClient.GetAppSlug()`), with new unit tests covering injection and deduplication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6a4bb82fb59703c613c34ad2eebdff0ae6a7898. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->