### PR TITLE
V1.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Goliac v1.8.6
+- bugfix: retry branch protection mutation with PAT when the integration error is returned
+
 ## Goliac v1.8.5
 
 - improvement: add Goliac app on repositories branch protection bypass when the repository is part of a workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Goliac v1.8.6
 - bugfix: retry branch protection mutation with PAT when the integration error is returned
+- validation improvement: validate when the required status checks are defined, at least one is required
 
 ## Goliac v1.8.5
 

--- a/internal/engine/remote.go
+++ b/internal/engine/remote.go
@@ -53,8 +53,8 @@ type GoliacRemote interface {
 
 	IsEnterprise() bool // check if we are on an Enterprise version, or if we are on GHES 3.11+
 
-	CountAssets(ctx context.Context, warmup bool) (int, error)         // return the number of (some) assets that will be loaded (to be used with the RemoteObservability/progress bar)
-	SetRemoteObservability(feedback observability.RemoteObservability) // if you want to get feedback on the loading process
+	CountAssets(ctx context.Context, warmup bool) (int, error)                                              // return the number of (some) assets that will be loaded (to be used with the RemoteObservability/progress bar)
+	SetRemoteObservability(feedback observability.RemoteObservability)                                      // if you want to get feedback on the loading process
 	SetFeatureFlags(manageGithubVariables bool, manageGithubAutolinks bool, manageOrgCustomProperties bool) // needed becasue we dont know at construction what are the values
 
 	RepositoriesSecretsPerRepository(ctx context.Context, repositoryName string) (map[string]*GithubVariable, error)
@@ -3065,22 +3065,103 @@ mutation createBranchProtectionRule(
   }
 }`
 
-type GraphqlBranchProtectionRuleCreationResponse struct {
+// GraphqlBranchProtectionMutationError is the shared GraphQL error object for branch protection mutations.
+type GraphqlBranchProtectionMutationError struct {
+	Path       []interface{} `json:"path"`
+	Extensions struct {
+		Code         string
+		ErrorMessage string
+	} `json:"extensions"`
+	Message string `json:"message"`
+}
+
+// GraphqlBranchProtectionRuleCreateMutationResponse is the response body for createBranchProtectionRule.
+type GraphqlBranchProtectionRuleCreateMutationResponse struct {
 	Data struct {
 		CreateBranchProtectionRule struct {
 			BranchProtectionRule struct {
-				Id string
-			}
+				Id string `json:"id"`
+			} `json:"branchProtectionRule"`
+		} `json:"createBranchProtectionRule"`
+	} `json:"data"`
+	Errors []GraphqlBranchProtectionMutationError `json:"errors"`
+}
+
+// GraphqlBranchProtectionRuleUpdateMutationResponse is the response body for updateBranchProtectionRule.
+type GraphqlBranchProtectionRuleUpdateMutationResponse struct {
+	Data struct {
+		UpdateBranchProtectionRule struct {
+			BranchProtectionRule struct {
+				Id string `json:"id"`
+			} `json:"branchProtectionRule"`
+		} `json:"updateBranchProtectionRule"`
+	} `json:"data"`
+	Errors []GraphqlBranchProtectionMutationError `json:"errors"`
+}
+
+// GraphqlBranchProtectionRuleDeleteMutationResponse is the response body for deleteBranchProtectionRule.
+type GraphqlBranchProtectionRuleDeleteMutationResponse struct {
+	Data struct {
+		DeleteBranchProtectionRule struct {
+			ClientMutationId *string `json:"clientMutationId"`
+		} `json:"deleteBranchProtectionRule"`
+	} `json:"data"`
+	Errors []GraphqlBranchProtectionMutationError `json:"errors"`
+}
+
+func graphqlErrorResourceNotAccessibleByIntegration(msg string) bool {
+	return strings.Contains(msg, "Resource not accessible by integration")
+}
+
+func branchProtectionMutationErrorsForPATRetry(v any) []GraphqlBranchProtectionMutationError {
+	switch x := v.(type) {
+	case *GraphqlBranchProtectionRuleCreateMutationResponse:
+		return x.Errors
+	case *GraphqlBranchProtectionRuleUpdateMutationResponse:
+		return x.Errors
+	case *GraphqlBranchProtectionRuleDeleteMutationResponse:
+		return x.Errors
+	default:
+		return nil
+	}
+}
+
+func shouldRetryBranchProtectionMutationWithPAT(res any) bool {
+	errs := branchProtectionMutationErrorsForPATRetry(res)
+	return len(errs) > 0 &&
+		graphqlErrorResourceNotAccessibleByIntegration(errs[0].Message) &&
+		config.Config.GithubPersonalAccessToken != ""
+}
+
+// queryGraphQLBranchProtectionMutationWithPATRetry runs a branch protection mutation with the installation token,
+// and retries once with GOLIAC_GITHUB_PERSONAL_ACCESS_TOKEN if GitHub returns Resource not accessible by integration.
+// It is a package-level generic function because Go does not allow type parameters on methods.
+func queryGraphQLBranchProtectionMutationWithPATRetry[T any](g *GoliacRemoteImpl, ctx context.Context, query string, variables map[string]interface{}) ([]byte, T, error) {
+	var zero T
+	body, err := g.client.QueryGraphQLAPI(ctx, query, variables, nil)
+	if err != nil {
+		return body, zero, err
+	}
+	var res T
+	if err = json.Unmarshal(body, &res); err != nil {
+		return body, res, err
+	}
+	if shouldRetryBranchProtectionMutationWithPAT(&res) {
+		logrus.Debugf("retrying branch protection GraphQL mutation with personal access token after integration error")
+		pat := config.Config.GithubPersonalAccessToken
+		body, err = g.client.QueryGraphQLAPI(ctx, query, variables, &pat)
+		if err != nil {
+			return body, zero, err
+		}
+		// Unmarshal into a fresh struct: json.Unmarshal does not clear fields missing from the second JSON,
+		// so a success body without "errors" would otherwise keep the first response's Errors slice.
+		res = zero
+		err = json.Unmarshal(body, &res)
+		if err != nil {
+			return body, res, err
 		}
 	}
-	Errors []struct {
-		Path       []interface{} `json:"path"`
-		Extensions struct {
-			Code         string
-			ErrorMessage string
-		} `json:"extensions"`
-		Message string
-	} `json:"errors"`
+	return body, res, nil
 }
 
 func (g *GoliacRemoteImpl) AddRepositoryBranchProtection(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, branchprotection *GithubBranchProtection) {
@@ -3120,7 +3201,7 @@ func (g *GoliacRemoteImpl) AddRepositoryBranchProtection(ctx context.Context, lo
 	}
 
 	if !dryrun {
-		body, err := g.client.QueryGraphQLAPI(
+		body, res, err := queryGraphQLBranchProtectionMutationWithPATRetry[GraphqlBranchProtectionRuleCreateMutationResponse](g,
 			ctx,
 			createBranchProtectionRule,
 			map[string]interface{}{
@@ -3141,17 +3222,9 @@ func (g *GoliacRemoteImpl) AddRepositoryBranchProtection(ctx context.Context, lo
 				"allowsDeletions":                branchprotection.AllowsDeletions,
 				"bypassPullRequestActorIds":      bypassPullRequestActorIds,
 			},
-			nil,
 		)
 		if err != nil {
 			logsCollector.AddError(fmt.Errorf("failed to add branch protection to repository %s: %v. %s", reponame, err, string(body)))
-			return
-		}
-
-		var res GraphqlBranchProtectionRuleCreationResponse
-		err = json.Unmarshal(body, &res)
-		if err != nil {
-			logsCollector.AddError(fmt.Errorf("failed to add branch protection to repository %s: %v", reponame, err))
 			return
 		}
 		if len(res.Errors) > 0 {
@@ -3265,7 +3338,7 @@ func (g *GoliacRemoteImpl) UpdateRepositoryBranchProtection(ctx context.Context,
 		if statusCheckContexts == nil {
 			statusCheckContexts = []string{}
 		}
-		body, err := g.client.QueryGraphQLAPI(
+		body, res, err := queryGraphQLBranchProtectionMutationWithPATRetry[GraphqlBranchProtectionRuleUpdateMutationResponse](g,
 			ctx,
 			updateBranchProtectionRule,
 			map[string]interface{}{
@@ -3286,17 +3359,9 @@ func (g *GoliacRemoteImpl) UpdateRepositoryBranchProtection(ctx context.Context,
 				"allowsDeletions":                branchprotection.AllowsDeletions,
 				"bypassPullRequestActorIds":      bypassPullRequestActorIds,
 			},
-			nil,
 		)
 		if err != nil {
 			logsCollector.AddError(fmt.Errorf("failed to update branch protection for repository %s: %v. %s", reponame, err, string(body)))
-			return
-		}
-
-		var res GraphqlBranchProtectionRuleCreationResponse
-		err = json.Unmarshal(body, &res)
-		if err != nil {
-			logsCollector.AddError(fmt.Errorf("failed to update branch protection for repository %s: %v", reponame, err))
 			return
 		}
 		if len(res.Errors) > 0 {
@@ -3345,23 +3410,15 @@ func (g *GoliacRemoteImpl) DeleteRepositoryBranchProtection(ctx context.Context,
 	}
 
 	if !dryrun {
-		body, err := g.client.QueryGraphQLAPI(
+		body, res, err := queryGraphQLBranchProtectionMutationWithPATRetry[GraphqlBranchProtectionRuleDeleteMutationResponse](g,
 			ctx,
 			deleteBranchProtectionRule,
 			map[string]interface{}{
 				"branchProtectionRuleId": branchprotection.Id,
 			},
-			nil,
 		)
 		if err != nil {
 			logsCollector.AddError(fmt.Errorf("failed to delete branch protection for repository %s: %v. %s", reponame, err, string(body)))
-			return
-		}
-
-		var res GraphqlBranchProtectionRuleCreationResponse
-		err = json.Unmarshal(body, &res)
-		if err != nil {
-			logsCollector.AddError(fmt.Errorf("failed to delete branch protection for repository %s: %v", reponame, err))
 			return
 		}
 		if len(res.Errors) > 0 {

--- a/internal/engine/remote.go
+++ b/internal/engine/remote.go
@@ -2738,6 +2738,10 @@ func (g *GoliacRemoteImpl) prepareRuleset(ruleset *GithubRuleSet) map[string]int
 					"context": s,
 				})
 			}
+			if len(statusChecks) == 0 {
+				logrus.Warnf("skipping required_status_checks rule in ruleset %q: GitHub requires at least one status check context", ruleset.Name)
+				break
+			}
 			rules = append(rules, map[string]interface{}{
 				"type": "required_status_checks",
 				"parameters": map[string]interface{}{

--- a/internal/engine/remote_repository_branchprotection_test.go
+++ b/internal/engine/remote_repository_branchprotection_test.go
@@ -2,9 +2,11 @@ package engine
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
+	"github.com/goliac-project/goliac/internal/config"
 	"github.com/goliac-project/goliac/internal/observability"
 	"github.com/stretchr/testify/assert"
 )
@@ -14,21 +16,29 @@ type AddBranchProtectionMockClient struct {
 	// Track calls to verify test behavior
 	lastGraphQLQuery string
 	lastVariables    map[string]interface{}
+	lastGithubToken  *string
 
 	// Configure mock responses
 	shouldError  bool
 	errorMessage string
 	responseBody string
+	callCount    int
+	responses    []string
 }
 
 func (m *AddBranchProtectionMockClient) QueryGraphQLAPI(ctx context.Context, query string, variables map[string]interface{}, githubToken *string) ([]byte, error) {
 	m.lastGraphQLQuery = query
 	m.lastVariables = variables
+	m.lastGithubToken = githubToken
+	i := m.callCount
+	m.callCount++
 
 	if m.shouldError {
 		return []byte(m.errorMessage), errors.New(m.errorMessage)
 	}
-
+	if len(m.responses) > 0 && i < len(m.responses) {
+		return []byte(m.responses[i]), nil
+	}
 	if m.responseBody != "" {
 		return []byte(m.responseBody), nil
 	}
@@ -280,21 +290,29 @@ type DeleteBranchProtectionMockClient struct {
 	// Track calls to verify test behavior
 	lastGraphQLQuery string
 	lastVariables    map[string]interface{}
+	lastGithubToken  *string
 
 	// Configure mock responses
 	shouldError  bool
 	errorMessage string
 	responseBody string
+	callCount    int
+	responses    []string
 }
 
 func (m *DeleteBranchProtectionMockClient) QueryGraphQLAPI(ctx context.Context, query string, variables map[string]interface{}, githubToken *string) ([]byte, error) {
 	m.lastGraphQLQuery = query
 	m.lastVariables = variables
+	m.lastGithubToken = githubToken
+	i := m.callCount
+	m.callCount++
 
 	if m.shouldError {
 		return []byte(m.errorMessage), errors.New(m.errorMessage)
 	}
-
+	if len(m.responses) > 0 && i < len(m.responses) {
+		return []byte(m.responses[i]), nil
+	}
 	if m.responseBody != "" {
 		return []byte(m.responseBody), nil
 	}
@@ -557,21 +575,29 @@ type UpdateBranchProtectionMockClient struct {
 	// Track calls to verify test behavior
 	lastGraphQLQuery string
 	lastVariables    map[string]interface{}
+	lastGithubToken  *string
 
 	// Configure mock responses
 	shouldError  bool
 	errorMessage string
 	responseBody string
+	callCount    int
+	responses    []string
 }
 
 func (m *UpdateBranchProtectionMockClient) QueryGraphQLAPI(ctx context.Context, query string, variables map[string]interface{}, githubToken *string) ([]byte, error) {
 	m.lastGraphQLQuery = query
 	m.lastVariables = variables
+	m.lastGithubToken = githubToken
+	i := m.callCount
+	m.callCount++
 
 	if m.shouldError {
 		return []byte(m.errorMessage), errors.New(m.errorMessage)
 	}
-
+	if len(m.responses) > 0 && i < len(m.responses) {
+		return []byte(m.responses[i]), nil
+	}
 	if m.responseBody != "" {
 		return []byte(m.responseBody), nil
 	}
@@ -860,5 +886,207 @@ func TestUpdateRepositoryBranchProtection(t *testing.T) {
 
 		// Verify the branch protection remains unchanged in the cache
 		assert.Equal(t, originalBranchProtection, repo.BranchProtections["main"])
+	})
+}
+
+func TestQueryGraphQLBranchProtectionMutationPATRetry(t *testing.T) {
+	pat := "test-admin-pat"
+	savePAT := config.Config.GithubPersonalAccessToken
+	t.Cleanup(func() { config.Config.GithubPersonalAccessToken = savePAT })
+	config.Config.GithubPersonalAccessToken = pat
+
+	mockClient := &AddBranchProtectionMockClient{
+		responses: []string{
+			`{"errors":[{"message":"Resource not accessible by integration ([createBranchProtectionRule])","path":["createBranchProtectionRule"]}]}`,
+			`{"data":{"createBranchProtectionRule":{"branchProtectionRule":{"id":"BP_456"}}}}`,
+		},
+	}
+	remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
+	ctx := context.TODO()
+	_, res, err := queryGraphQLBranchProtectionMutationWithPATRetry[GraphqlBranchProtectionRuleCreateMutationResponse](remoteImpl, ctx, createBranchProtectionRule, map[string]interface{}{
+		"repositoryId": "R_1",
+	})
+	assert.NoError(t, err)
+	assert.Empty(t, res.Errors)
+	assert.Equal(t, "BP_456", res.Data.CreateBranchProtectionRule.BranchProtectionRule.Id)
+	assert.Equal(t, 2, mockClient.callCount)
+	assert.NotNil(t, mockClient.lastGithubToken)
+	assert.Equal(t, pat, *mockClient.lastGithubToken)
+}
+
+func TestBranchProtectionGraphQLPATFallbackRetry(t *testing.T) {
+	pat := "test-admin-pat"
+	savePAT := config.Config.GithubPersonalAccessToken
+	t.Cleanup(func() { config.Config.GithubPersonalAccessToken = savePAT })
+
+	t.Run("Add retry with PAT after integration error", func(t *testing.T) {
+		config.Config.GithubPersonalAccessToken = pat
+		mockClient := &AddBranchProtectionMockClient{
+			responses: []string{
+				`{"errors":[{"message":"Resource not accessible by integration ([createBranchProtectionRule])","path":["createBranchProtectionRule"]}]}`,
+				`{"data":{"createBranchProtectionRule":{"branchProtectionRule":{"id":"BP_456"}}}}`,
+			},
+		}
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
+		repo := &GithubRepository{
+			Name:              "test-repo",
+			Id:                123,
+			RefId:             "R_123",
+			BranchProtections: make(map[string]*GithubBranchProtection),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{"test-repo": repo}
+		bp := &GithubBranchProtection{Pattern: "main"}
+
+		ctx := context.TODO()
+		logsCollector := observability.NewLogCollection()
+		remoteImpl.AddRepositoryBranchProtection(ctx, logsCollector, false, "test-repo", bp)
+
+		assert.False(t, logsCollector.HasErrors())
+		assert.Equal(t, 2, mockClient.callCount)
+		assert.NotNil(t, mockClient.lastGithubToken)
+		assert.Equal(t, pat, *mockClient.lastGithubToken)
+		assert.Equal(t, "BP_456", repo.BranchProtections["main"].Id)
+	})
+
+	t.Run("Update retry with PAT after integration error", func(t *testing.T) {
+		config.Config.GithubPersonalAccessToken = pat
+		mockClient := &UpdateBranchProtectionMockClient{
+			responses: []string{
+				`{"errors":[{"message":"Resource not accessible by integration ([updateBranchProtectionRule])","path":["updateBranchProtectionRule"]}]}`,
+				`{"data":{"updateBranchProtectionRule":{"branchProtectionRule":{"id":"BP_123"}}}}`,
+			},
+		}
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
+		existing := &GithubBranchProtection{Id: "BP_123", Pattern: "main"}
+		repo := &GithubRepository{
+			Name:              "test-repo",
+			Id:                123,
+			RefId:             "R_123",
+			BranchProtections: map[string]*GithubBranchProtection{"main": existing},
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{"test-repo": repo}
+		updated := &GithubBranchProtection{Id: "BP_123", Pattern: "main", RequiresApprovingReviews: true}
+
+		ctx := context.TODO()
+		logsCollector := observability.NewLogCollection()
+		remoteImpl.UpdateRepositoryBranchProtection(ctx, logsCollector, false, "test-repo", updated)
+
+		assert.False(t, logsCollector.HasErrors())
+		assert.Equal(t, 2, mockClient.callCount)
+		assert.NotNil(t, mockClient.lastGithubToken)
+		assert.Equal(t, pat, *mockClient.lastGithubToken)
+	})
+
+	t.Run("Delete retry with PAT after integration error", func(t *testing.T) {
+		config.Config.GithubPersonalAccessToken = pat
+		mockClient := &DeleteBranchProtectionMockClient{
+			responses: []string{
+				`{"errors":[{"message":"Resource not accessible by integration ([deleteBranchProtectionRule])","path":["deleteBranchProtectionRule"]}]}`,
+				`{"data":{"deleteBranchProtectionRule":{"clientMutationId":"x"}}}`,
+			},
+		}
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
+		bp := &GithubBranchProtection{Id: "BP_123", Pattern: "main"}
+		repo := &GithubRepository{
+			Name:              "test-repo",
+			Id:                123,
+			RefId:             "R_123",
+			BranchProtections: map[string]*GithubBranchProtection{"main": bp},
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{"test-repo": repo}
+
+		ctx := context.TODO()
+		logsCollector := observability.NewLogCollection()
+		remoteImpl.DeleteRepositoryBranchProtection(ctx, logsCollector, false, "test-repo", bp)
+
+		assert.False(t, logsCollector.HasErrors())
+		assert.Equal(t, 2, mockClient.callCount)
+		assert.NotNil(t, mockClient.lastGithubToken)
+		assert.Equal(t, pat, *mockClient.lastGithubToken)
+		assert.NotContains(t, repo.BranchProtections, "main")
+	})
+
+	t.Run("integration error without PAT does not retry", func(t *testing.T) {
+		config.Config.GithubPersonalAccessToken = ""
+		mockClient := &UpdateBranchProtectionMockClient{
+			responses: []string{
+				`{"errors":[{"message":"Resource not accessible by integration ([updateBranchProtectionRule])","path":["updateBranchProtectionRule"]}]}`,
+			},
+		}
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
+		existing := &GithubBranchProtection{Id: "BP_123", Pattern: "main"}
+		repo := &GithubRepository{
+			Name:              "test-repo",
+			Id:                123,
+			RefId:             "R_123",
+			BranchProtections: map[string]*GithubBranchProtection{"main": existing},
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{"test-repo": repo}
+		updated := &GithubBranchProtection{Id: "BP_123", Pattern: "main", RequiresApprovingReviews: true}
+
+		ctx := context.TODO()
+		logsCollector := observability.NewLogCollection()
+		remoteImpl.UpdateRepositoryBranchProtection(ctx, logsCollector, false, "test-repo", updated)
+
+		assert.True(t, logsCollector.HasErrors())
+		assert.Equal(t, 1, mockClient.callCount)
+		assert.Nil(t, mockClient.lastGithubToken)
+		assert.Equal(t, existing, repo.BranchProtections["main"])
+	})
+
+	t.Run("non-integration GraphQL error does not retry with PAT", func(t *testing.T) {
+		config.Config.GithubPersonalAccessToken = pat
+		mockClient := &UpdateBranchProtectionMockClient{
+			responses: []string{
+				`{"errors":[{"message":"Invalid branch protection configuration","path":["updateBranchProtectionRule"]}]}`,
+			},
+		}
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
+		existing := &GithubBranchProtection{Id: "BP_123", Pattern: "main"}
+		repo := &GithubRepository{
+			Name:              "test-repo",
+			Id:                123,
+			RefId:             "R_123",
+			BranchProtections: map[string]*GithubBranchProtection{"main": existing},
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{"test-repo": repo}
+		updated := &GithubBranchProtection{Id: "BP_123", Pattern: "main", RequiresApprovingReviews: true}
+
+		ctx := context.TODO()
+		logsCollector := observability.NewLogCollection()
+		remoteImpl.UpdateRepositoryBranchProtection(ctx, logsCollector, false, "test-repo", updated)
+
+		assert.True(t, logsCollector.HasErrors())
+		assert.Equal(t, 1, mockClient.callCount)
+		assert.Nil(t, mockClient.lastGithubToken)
+	})
+}
+
+func TestGraphqlBranchProtectionRuleMutationResponseUnmarshal(t *testing.T) {
+	t.Run("create success", func(t *testing.T) {
+		var res GraphqlBranchProtectionRuleCreateMutationResponse
+		err := json.Unmarshal([]byte(`{"data":{"createBranchProtectionRule":{"branchProtectionRule":{"id":"BP_1"}}}}`), &res)
+		assert.NoError(t, err)
+		assert.Equal(t, "BP_1", res.Data.CreateBranchProtectionRule.BranchProtectionRule.Id)
+	})
+	t.Run("update success", func(t *testing.T) {
+		var res GraphqlBranchProtectionRuleUpdateMutationResponse
+		err := json.Unmarshal([]byte(`{"data":{"updateBranchProtectionRule":{"branchProtectionRule":{"id":"BP_2"}}}}`), &res)
+		assert.NoError(t, err)
+		assert.Equal(t, "BP_2", res.Data.UpdateBranchProtectionRule.BranchProtectionRule.Id)
+	})
+	t.Run("delete success", func(t *testing.T) {
+		var res GraphqlBranchProtectionRuleDeleteMutationResponse
+		err := json.Unmarshal([]byte(`{"data":{"deleteBranchProtectionRule":{"clientMutationId":"x"}}}`), &res)
+		assert.NoError(t, err)
+		assert.NotNil(t, res.Data.DeleteBranchProtectionRule.ClientMutationId)
+		assert.Equal(t, "x", *res.Data.DeleteBranchProtectionRule.ClientMutationId)
+	})
+	t.Run("graphql error", func(t *testing.T) {
+		var res GraphqlBranchProtectionRuleUpdateMutationResponse
+		err := json.Unmarshal([]byte(`{"errors":[{"message":"oops","path":["updateBranchProtectionRule"]}]}`), &res)
+		assert.NoError(t, err)
+		assert.Len(t, res.Errors, 1)
+		assert.Equal(t, "oops", res.Errors[0].Message)
 	})
 }

--- a/internal/engine/remote_test.go
+++ b/internal/engine/remote_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/goliac-project/goliac/internal/entity"
 	"github.com/goliac-project/goliac/internal/github"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
@@ -737,5 +738,22 @@ repositories:
 		assert.Equal(t, 1, len(payload["bypass_actors"].([]map[string]interface{})))
 		// Github API uses refs/heads/ as prefix
 		assert.Equal(t, "refs/heads/main", payload["conditions"].(map[string]interface{})["ref_name"].(map[string]interface{})["include"].([]string)[0])
+	})
+
+	t.Run("omits required_status_checks when no contexts (API hardening)", func(t *testing.T) {
+		ghClient := MockGithubClient{}
+		g := NewGoliacRemoteImpl(&ghClient, "myorg", true, true, true)
+		ruleset := GithubRuleSet{
+			Name:        "ruleset-empty-checks",
+			Enforcement: "evaluate",
+			Rules: map[string]entity.RuleSetParameters{
+				"required_status_checks": {
+					RequiredStatusChecks: []string{},
+				},
+			},
+		}
+		payload := g.prepareRuleset(&ruleset)
+		rules := payload["rules"].([]map[string]interface{})
+		assert.Empty(t, rules)
 	})
 }

--- a/internal/entity/entity_ruleset.go
+++ b/internal/entity/entity_ruleset.go
@@ -311,6 +311,11 @@ func ValidateRulesetDefinition(r *RuleSetDefinition, filename string) error {
 				return fmt.Errorf("invalid ruletype: %s for ruleset filename %s: mergeMethod must be 'MERGE', 'REBASE' or 'SQUASH' ", rule.Ruletype, filename)
 			}
 		}
+		if rule.Ruletype == "required_status_checks" {
+			if len(rule.Parameters.RequiredStatusChecks) == 0 {
+				return fmt.Errorf("invalid ruletype: %s for ruleset filename %s: requiredStatusChecks must list at least one context (GitHub requires at least one status check)", rule.Ruletype, filename)
+			}
+		}
 	}
 
 	if r.Enforcement != "disabled" && r.Enforcement != "active" && r.Enforcement != "evaluate" {

--- a/internal/entity/entity_ruletset_test.go
+++ b/internal/entity/entity_ruletset_test.go
@@ -129,3 +129,48 @@ func TestRulesetParametersComparison(t *testing.T) {
 		assert.Equal(t, "disabled", rulesets["ruleset2"].Spec.Ruleset.Enforcement)
 	})
 }
+
+func TestValidateRulesetDefinitionRequiredStatusChecks(t *testing.T) {
+	ruleType := []struct {
+		Ruletype   string
+		Parameters RuleSetParameters `yaml:"parameters,omitempty"`
+	}{
+		{Ruletype: "required_status_checks", Parameters: RuleSetParameters{RequiredStatusChecks: nil}},
+	}
+	def := RuleSetDefinition{Enforcement: "evaluate", Rules: ruleType}
+
+	t.Run("nil requiredStatusChecks fails", func(t *testing.T) {
+		err := ValidateRulesetDefinition(&def, "repo.yaml")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "requiredStatusChecks")
+	})
+
+	t.Run("empty slice requiredStatusChecks fails", func(t *testing.T) {
+		def2 := RuleSetDefinition{
+			Enforcement: "evaluate",
+			Rules: []struct {
+				Ruletype   string
+				Parameters RuleSetParameters `yaml:"parameters,omitempty"`
+			}{
+				{Ruletype: "required_status_checks", Parameters: RuleSetParameters{RequiredStatusChecks: []string{}}},
+			},
+		}
+		err := ValidateRulesetDefinition(&def2, "repo.yaml")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "requiredStatusChecks")
+	})
+
+	t.Run("at least one context passes", func(t *testing.T) {
+		def3 := RuleSetDefinition{
+			Enforcement: "evaluate",
+			Rules: []struct {
+				Ruletype   string
+				Parameters RuleSetParameters `yaml:"parameters,omitempty"`
+			}{
+				{Ruletype: "required_status_checks", Parameters: RuleSetParameters{RequiredStatusChecks: []string{"ci"}}},
+			},
+		}
+		err := ValidateRulesetDefinition(&def3, "repo.yaml")
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how branch protection mutations are executed (including optional PAT fallback), which can affect permission behavior and mutation outcomes. Adds stricter ruleset validation that may cause previously-accepted configs to fail fast.
> 
> **Overview**
> **Improves reliability of branch protection updates** by introducing a shared GraphQL mutation wrapper that retries `create/update/deleteBranchProtectionRule` once with `GOLIAC_GITHUB_PERSONAL_ACCESS_TOKEN` when GitHub returns *"Resource not accessible by integration"*.
> 
> **Hardens ruleset handling** by rejecting `required_status_checks` rules with zero contexts during validation, and by omitting that rule from the REST payload if encountered at runtime (with a warning) to match GitHub API requirements. Includes expanded unit tests covering PAT retry behavior and new validation rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 346b453cea4f66d70131ea183f4d438a057e9820. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->