### PR TITLE
V1 8 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
+## Goliac v1.8.7
+
+- bugfix: add Goliac app on repositories branch protection bypass when the repository is part of a workflow and if a CODEOWNER review is required
+
 ## Goliac v1.8.6
+
 - bugfix: retry branch protection mutation with PAT when the integration error is returned
 - validation improvement: validate when the required status checks are defined, at least one is required
 

--- a/internal/engine/goliac_reconciliator_datasource.go
+++ b/internal/engine/goliac_reconciliator_datasource.go
@@ -302,12 +302,21 @@ func (d *GoliacReconciliatorDatasourceLocal) Repositories() (map[string]*GithubR
 			branchprotections[bp.Pattern] = &branchprotection
 		}
 
+		// we need to add the Goliac app on the branch protection bypass
+		// if the repository is part of a workflow and if a CODEOWNER review is required
+		// the goal is to allow the Goliac app to bypass the CODEOWNER review when the repository is part of a workflow
 		if d.githubAppSlug != "" && (len(branchprotections) > 0 || len(rulesets) > 0) && d.local.RepositoryInWorkflow(reponame) {
 			for _, bp := range branchprotections {
-				ensureGoliacAppBypassOnBranchProtection(bp, d.githubAppSlug)
+				if bp.RequiresCodeOwnerReviews {
+					ensureGoliacAppBypassOnBranchProtection(bp, d.githubAppSlug)
+				}
 			}
 			for _, rs := range rulesets {
-				ensureGoliacAppBypassOnRuleset(rs, d.githubAppSlug)
+				if r, ok := rs.Rules["pull_request"]; ok {
+					if r.RequireCodeOwnerReview {
+						ensureGoliacAppBypassOnRuleset(rs, d.githubAppSlug)
+					}
+				}
 			}
 		}
 

--- a/internal/engine/goliac_reconciliator_datasource_test.go
+++ b/internal/engine/goliac_reconciliator_datasource_test.go
@@ -24,7 +24,7 @@ func TestGoliacReconciliatorDatasourceLocalWorkflowBypassInjection(t *testing.T)
 
 	repo := &entity.Repository{}
 	repo.Spec.BranchProtections = []entity.RepositoryBranchProtection{
-		{Pattern: "main", RequiresApprovingReviews: true},
+		{Pattern: "main", RequiresApprovingReviews: true, RequiresCodeOwnerReviews: true},
 	}
 	local.repositories["myrepo"] = repo
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes branch protection/ruleset bypass injection logic, which can affect merge governance for workflow-scoped repositories if CODEOWNERS requirements are misdetected or vary across protections/rulesets.
> 
> **Overview**
> **Tightens automatic bypass injection for the Goliac GitHub App**: when a repository is part of a workflow, the app is now only added to branch protection/ruleset bypass lists if *CODEOWNERS review is required* (`RequiresCodeOwnerReviews` on branch protections, or `pull_request.RequireCodeOwnerReview` on rulesets).
> 
> Updates the v1.8.7 changelog entry and adjusts the workflow bypass injection test fixture to require CODEOWNERS reviews.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf172d56a8ea5056f96fcfd1edd10b63c49d65ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->