### PR TITLE
V1 8 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Goliac v1.8.8
+
+- bugfix: nil pointer fix
+
 ## Goliac v1.8.7
 
 - bugfix: add Goliac app on repositories branch protection bypass when the repository is part of a workflow and if a CODEOWNER review is required

--- a/internal/engine/remote.go
+++ b/internal/engine/remote.go
@@ -3244,6 +3244,9 @@ func (g *GoliacRemoteImpl) AddRepositoryBranchProtection(ctx context.Context, lo
 
 	repo = g.repositories[reponame]
 	if repo != nil {
+		if repo.BranchProtections == nil {
+			repo.BranchProtections = make(map[string]*GithubBranchProtection)
+		}
 		repo.BranchProtections[branchprotection.Pattern] = branchprotection
 	}
 }
@@ -3379,6 +3382,9 @@ func (g *GoliacRemoteImpl) UpdateRepositoryBranchProtection(ctx context.Context,
 
 	repo = g.repositories[reponame]
 	if repo != nil {
+		if repo.BranchProtections == nil {
+			repo.BranchProtections = make(map[string]*GithubBranchProtection)
+		}
 		repo.BranchProtections[branchprotection.Pattern] = branchprotection
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk bugfix that only adds defensive initialization to avoid a nil-pointer panic when updating in-memory `BranchProtections` after branch protection create/update operations.
> 
> **Overview**
> **Fixes a potential panic when applying branch protection changes.** After creating or updating a repository branch protection rule, the code now ensures the repo’s `BranchProtections` map is initialized before writing the updated entry.
> 
> Updates `CHANGELOG.md` for `v1.8.8` to note the nil-pointer bugfix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5304e5ed8b6ec30ea4627a1266e8a73aaa867cc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->