### PR TITLE
V1.8.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Goliac v1.8.10
+
+- bugfix: resolve GitHub app slug to GraphQL node ID when creating branch protection rules with app bypass actors (create path now matches the update path)
+
 ## Goliac v1.8.9
 
 - various library updates (security updates)

--- a/internal/engine/remote.go
+++ b/internal/engine/remote.go
@@ -3184,6 +3184,7 @@ func (g *GoliacRemoteImpl) AddRepositoryBranchProtection(ctx context.Context, lo
 	bypassPullRequestActorIds := []string{}
 	users := g.users
 	teams := g.teams
+	apps := g.appIds
 	for _, actor := range branchprotection.BypassPullRequestAllowances.Nodes {
 		if actor.Actor.UserLogin != "" {
 			for login, u := range users {
@@ -3200,7 +3201,11 @@ func (g *GoliacRemoteImpl) AddRepositoryBranchProtection(ctx context.Context, lo
 			}
 		}
 		if actor.Actor.AppSlug != "" {
-			bypassPullRequestActorIds = append(bypassPullRequestActorIds, actor.Actor.AppSlug)
+			for slug, a := range apps {
+				if slug == actor.Actor.AppSlug {
+					bypassPullRequestActorIds = append(bypassPullRequestActorIds, a.GraphqlId)
+				}
+			}
 		}
 	}
 

--- a/internal/engine/remote_repository_branchprotection_test.go
+++ b/internal/engine/remote_repository_branchprotection_test.go
@@ -141,6 +141,57 @@ func TestAddRepositoryBranchProtection(t *testing.T) {
 		assert.Equal(t, "BP_123", repo.BranchProtections["main"].Id)
 	})
 
+	t.Run("app bypass actor uses GraphQL node id from appIds", func(t *testing.T) {
+		mockClient := &AddBranchProtectionMockClient{}
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
+
+		repo := &GithubRepository{
+			Name:              "test-repo",
+			Id:                123,
+			RefId:             "R_123",
+			BranchProtections: make(map[string]*GithubBranchProtection),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+		remoteImpl.appIds = map[string]*GithubApp{
+			"my-app": {
+				Slug:      "my-app",
+				GraphqlId: "A_app_node_id",
+			},
+		}
+
+		branchProtection := &GithubBranchProtection{
+			Pattern:                        "main",
+			RequiresApprovingReviews:       true,
+			RequiredApprovingReviewCount:   2,
+			DismissesStaleReviews:          true,
+			RequiresCodeOwnerReviews:       true,
+			RequireLastPushApproval:        true,
+			RequiresStatusChecks:           true,
+			RequiresStrictStatusChecks:     true,
+			RequiredStatusCheckContexts:    []string{"test-check"},
+			RequiresConversationResolution: true,
+			RequiresCommitSignatures:       true,
+			RequiresLinearHistory:          true,
+			AllowsForcePushes:              false,
+			AllowsDeletions:                false,
+		}
+		var bypassNode BypassPullRequestAllowanceNode
+		bypassNode.Actor.AppSlug = "my-app"
+		branchProtection.BypassPullRequestAllowances.Nodes = []BypassPullRequestAllowanceNode{bypassNode}
+
+		ctx := context.TODO()
+		logsCollector := observability.NewLogCollection()
+
+		remoteImpl.AddRepositoryBranchProtection(ctx, logsCollector, false, "test-repo", branchProtection)
+
+		assert.False(t, logsCollector.HasErrors())
+		ids, ok := mockClient.lastVariables["bypassPullRequestActorIds"].([]string)
+		assert.True(t, ok)
+		assert.Equal(t, []string{"A_app_node_id"}, ids)
+	})
+
 	t.Run("error path: repository not found", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &AddBranchProtectionMockClient{}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches branch protection rule creation, which can affect repository enforcement and bypass behavior. Scope is small and covered by a targeted test, but mis-resolution could weaken or break protections.
> 
> **Overview**
> Fixes branch protection *creation* so bypass actors of type GitHub App are sent as GraphQL node IDs rather than raw app slugs, using the cached `appIds` mapping in `AddRepositoryBranchProtection`.
> 
> Adds a focused unit test ensuring `bypassPullRequestActorIds` contains the app’s GraphQL ID, and updates the changelog for `v1.8.10`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52ec82b216837cfb401bfc99c76072bcc05fe5b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->