### PR TITLE
V1.8.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Goliac v1.8.11
+
+- change the way commit title is generated when doing a forcemerge
+
 ## Goliac v1.8.10
 
 - bugfix: resolve GitHub app slug to GraphQL node ID when creating branch protection rules with app bypass actors (create path now matches the update path)

--- a/internal/workflow/workflow_forcemerge.go
+++ b/internal/workflow/workflow_forcemerge.go
@@ -128,7 +128,7 @@ func (g *ForcemergeImpl) mergePR(ctx context.Context, username string, repo stri
 		"Force merge via Goliac on behalf of %s.\n\nPR #%s: %s\n%s\n\n%s",
 		username, prNumber, prTitle, prURL, explanation,
 	)
-	commitTitle := fmt.Sprintf("PR %s: force merge for %s - %s", prNumber, username, prTitle)
+	commitTitle := fmt.Sprintf("%s (force merged PR %s by %s)", prTitle, prNumber, username)
 	commitMessage := fmt.Sprintf(
 		"Force merge via Goliac on behalf of %s.\n\nPR: %s\nTitle: %s",
 		username, prURL, prTitle,

--- a/internal/workflow/workflow_forcemerge.go
+++ b/internal/workflow/workflow_forcemerge.go
@@ -128,7 +128,7 @@ func (g *ForcemergeImpl) mergePR(ctx context.Context, username string, repo stri
 		"Force merge via Goliac on behalf of %s.\n\nPR #%s: %s\n%s\n\n%s",
 		username, prNumber, prTitle, prURL, explanation,
 	)
-	commitTitle := fmt.Sprintf("force merge PR #%s for %s - %s", prNumber, username, prTitle)
+	commitTitle := fmt.Sprintf("PR %s: force merge for %s - %s", prNumber, username, prTitle)
 	commitMessage := fmt.Sprintf(
 		"Force merge via Goliac on behalf of %s.\n\nPR: %s\nTitle: %s",
 		username, prURL, prTitle,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk string-format change affecting only the merge commit title generated during the force-merge workflow; potential impact is limited to downstream tooling that parses commit subjects.
> 
> **Overview**
> Updates the force-merge workflow to generate merge commit titles as `"<PR title> (force merged PR <number> by <user>)"` instead of the previous `"force merge PR #..."` prefix.
> 
> Adds a `v1.8.11` changelog entry noting the revised force-merge commit title format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52d68aaa368adf1c86c0431bffb11f732741f312. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->