### PR TITLE
V1 9 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Goliac v1.9.5
+
+- bugfix: when a GitHub repository name matches the teams definition only case-insensitively, reconcile by renaming the repository on GitHub to the exact name from the teams repo (avoids treating it as delete + create)
+- bugfix: during `goliac plan` (dry-run), `RenameRepository` now rekeys the in-memory GitHub cache so subsequent steps resolve repositories by the new name (fixes false `repository … not found` after case alignment or YAML `renameTo`)
+
 ## Goliac v1.9.4
 
 - Github page code fix for workflow

--- a/internal/engine/goliac_reconciliator.go
+++ b/internal/engine/goliac_reconciliator.go
@@ -415,6 +415,20 @@ func (r *GoliacReconciliatorImpl) reconciliateRepositories(
 	// let's get the remote now
 	rRepos := remote.Repositories()
 
+	// Rename GitHub repos whose name matches a local repo name case-insensitively
+	// but not exactly, so the subsequent CompareEntities diff works correctly.
+	lowerToRemote := make(map[string]string, len(rRepos))
+	for rname := range rRepos {
+		lowerToRemote[strings.ToLower(rname)] = rname
+	}
+	for lname := range lRepos {
+		if _, exactMatch := rRepos[lname]; !exactMatch {
+			if rname, ok := lowerToRemote[strings.ToLower(lname)]; ok && rname != lname {
+				r.RenameRepository(ctx, logsCollector, dryrun, remote, rname, lname)
+			}
+		}
+	}
+
 	// now we compare local (slugTeams) and remote (rTeams)
 
 	compareRepos := func(reponame string, lRepo *GithubRepoComparable, rRepo *GithubRepoComparable) bool {

--- a/internal/engine/goliac_reconciliator_test.go
+++ b/internal/engine/goliac_reconciliator_test.go
@@ -2568,6 +2568,149 @@ func TestReconciliationRepo(t *testing.T) {
 		assert.Equal(t, 0, len(recorder.RepositoriesUpdateProperty))
 	})
 
+	t.Run("happy path: auto-rename repo when GitHub name differs only by case", func(t *testing.T) {
+		recorder := NewReconciliatorListenerRecorder()
+		repoconf := config.RepositoryConfig{
+			AdminTeam:       "admin-team",
+			ArchiveOnDelete: false,
+		}
+		repoconf.DestructiveOperations.AllowDestructiveRepositories = true
+		r := NewGoliacReconciliatorImpl(false, recorder, &repoconf)
+
+		local := GoliacLocalMock{
+			users: make(map[string]*entity.User),
+			teams: make(map[string]*entity.Team),
+			repos: make(map[string]*entity.Repository),
+		}
+
+		lRepo := &entity.Repository{}
+		lRepo.Name = "MyRepo"
+		lRepo.Spec.Readers = []string{}
+		lRepo.Spec.Writers = []string{}
+		lRepo.Spec.ExternalUserWriters = []string{}
+		lRepo.Spec.AllowMergeCommit = true
+		lRepo.Spec.AllowRebaseMerge = true
+		lRepo.Spec.AllowSquashMerge = true
+		lowner := "existing"
+		lRepo.Owner = &lowner
+		local.repos["MyRepo"] = lRepo
+
+		adminTeam := &entity.Team{}
+		adminTeam.Name = "admin-team"
+		adminTeam.Spec.Owners = []string{"existing_owner"}
+		local.teams["admin-team"] = adminTeam
+
+		existingTeam := &entity.Team{}
+		existingTeam.Name = "existing"
+		existingTeam.Spec.Owners = []string{"existing_owner"}
+		existingTeam.Spec.Members = []string{}
+		local.teams["existing"] = existingTeam
+
+		remote := GoliacRemoteMock{
+			users:      make(map[string]*GithubUser),
+			teams:      make(map[string]*GithubTeam),
+			repos:      make(map[string]*GithubRepository),
+			teamsrepos: make(map[string]map[string]*GithubTeamRepo),
+			rulesets:   make(map[string]*GithubRuleSet),
+			appids:     make(map[string]*GithubApp),
+		}
+		rAdminTeam := &GithubTeam{
+			Name:    "admin-team",
+			Slug:    "admin-team",
+			Members: []string{"admin-team"},
+		}
+		remote.teams["admin-team"] = rAdminTeam
+
+		rAdminTeamOwners := &GithubTeam{
+			Name:    "admin-team-goliac-owners",
+			Slug:    "admin-team-goliac-owners",
+			Members: []string{"admin-team"},
+		}
+		remote.teams["admin-team-goliac-owners"] = rAdminTeamOwners
+
+		rExisting := &GithubTeam{
+			Name:    "existing",
+			Slug:    "existing",
+			Members: []string{"existing_owner"},
+		}
+		remote.teams["existing"] = rExisting
+
+		remote.repos["goliac-teams"] = &GithubRepository{
+			Name:              "goliac-teams",
+			Visibility:        "internal",
+			DefaultBranchName: "main",
+			ExternalUsers:     map[string]string{},
+			BoolProperties: map[string]bool{
+				"allow_auto_merge":       false,
+				"allow_squash_merge":     true,
+				"allow_merge_commit":     false,
+				"allow_rebase_merge":     false,
+				"archived":               false,
+				"delete_branch_on_merge": true,
+				"allow_update_branch":    false,
+			},
+			DefaultMergeCommitMessage:  "Default message",
+			DefaultSquashCommitMessage: "Default message",
+		}
+
+		existingOwner := &GithubTeam{
+			Name:    "existing-goliac-owners",
+			Slug:    "existing-goliac-owners",
+			Members: []string{"existing_owner"},
+		}
+		remote.teamsrepos["existing-goliac-owners"] = make(map[string]*GithubTeamRepo)
+		remote.teamsrepos["existing-goliac-owners"]["goliac-teams"] = &GithubTeamRepo{
+			Name:       "goliac-teams",
+			Permission: "WRITE",
+		}
+
+		remote.teams["existing-goliac-owners"] = existingOwner
+		rRepo := GithubRepository{
+			Name:          "myrepo",
+			ExternalUsers: make(map[string]string),
+			BoolProperties: map[string]bool{
+				"allow_auto_merge":       false,
+				"delete_branch_on_merge": false,
+				"allow_update_branch":    false,
+				"allow_squash_merge":     true,
+				"allow_merge_commit":     true,
+				"allow_rebase_merge":     true,
+				"archived":               false,
+			},
+		}
+		remote.repos["myrepo"] = &rRepo
+
+		remote.teamsrepos["admin-team"] = make(map[string]*GithubTeamRepo)
+		remote.teamsrepos["admin-team"]["goliac-teams"] = &GithubTeamRepo{
+			Name:       "goliac-teams",
+			Permission: "WRITE",
+		}
+		remote.teamsrepos["admin-team-goliac-owners"] = make(map[string]*GithubTeamRepo)
+		remote.teamsrepos["admin-team-goliac-owners"]["goliac-teams"] = &GithubTeamRepo{
+			Name:       "goliac-teams",
+			Permission: "WRITE",
+		}
+
+		remote.teamsrepos["existing"] = make(map[string]*GithubTeamRepo)
+		remote.teamsrepos["existing"]["myrepo"] = &GithubTeamRepo{
+			Name:       "myrepo",
+			Permission: "WRITE",
+		}
+
+		localDatasource := NewGoliacReconciliatorDatasourceLocal(&local, "goliac-teams", "main", true, &repoconf, "")
+		remoteDatasource := NewGoliacReconciliatorDatasourceRemote(&remote)
+
+		logsCollector := observability.NewLogCollection()
+		_, _, toRename, _ := r.Reconciliate(context.TODO(), logsCollector, localDatasource, remoteDatasource, true, false, true, true, true)
+
+		assert.False(t, logsCollector.HasErrors())
+		assert.Equal(t, 0, len(toRename))
+		assert.Equal(t, 0, len(recorder.RepositoryCreated))
+		assert.Equal(t, 0, len(recorder.RepositoriesDeleted))
+		assert.Equal(t, 1, len(recorder.RepositoriesRenamed))
+		assert.True(t, recorder.RepositoriesRenamed["myrepo"])
+	})
+
 	t.Run("happy path: change default branch of the repo", func(t *testing.T) {
 		recorder := NewReconciliatorListenerRecorder()
 		repoconf := config.RepositoryConfig{

--- a/internal/engine/remote.go
+++ b/internal/engine/remote.go
@@ -4642,7 +4642,7 @@ func (g *GoliacRemoteImpl) RenameRepository(ctx context.Context, logsCollector *
 		return
 	}
 
-	// update repository
+	// update repository on GitHub (skipped in dry-run / plan)
 	// https://docs.github.com/fr/rest/repos/repos?apiVersion=2022-11-28#update-a-repository
 	if !dryrun {
 		body, err := g.client.CallRestAPI(
@@ -4657,25 +4657,25 @@ func (g *GoliacRemoteImpl) RenameRepository(ctx context.Context, logsCollector *
 			logsCollector.AddError(fmt.Errorf("failed to rename the repository %s (to %s): %v. %s", reponame, newname, err, string(body)))
 			return
 		}
+	}
 
-		g.actionMutex.Lock()
-		defer g.actionMutex.Unlock()
+	g.actionMutex.Lock()
+	defer g.actionMutex.Unlock()
 
-		// update the repositories list
-		if r, ok := g.repositories[reponame]; ok {
-			delete(g.repositoriesByRefId, r.RefId)
-			delete(g.repositories, reponame)
-			r.Name = newname
-			g.repositories[newname] = r
-			g.repositoriesByRefId[r.RefId] = r
+	// Always rekey the in-memory cache (including dry-run / plan) so later steps resolve repositories by the new name.
+	if r, ok := g.repositories[reponame]; ok {
+		delete(g.repositoriesByRefId, r.RefId)
+		delete(g.repositories, reponame)
+		r.Name = newname
+		g.repositories[newname] = r
+		g.repositoriesByRefId[r.RefId] = r
 
-			for _, tr := range g.teamRepos {
-				for rname, r := range tr {
-					if rname == reponame {
-						delete(tr, rname)
-						r.Name = newname
-						tr[newname] = r
-					}
+		for _, tr := range g.teamRepos {
+			for rname, teamRepo := range tr {
+				if rname == reponame {
+					delete(tr, rname)
+					teamRepo.Name = newname
+					tr[newname] = teamRepo
 				}
 			}
 		}

--- a/internal/engine/remote_repository_test.go
+++ b/internal/engine/remote_repository_test.go
@@ -802,13 +802,69 @@ func TestRenameRepository(t *testing.T) {
 		assert.Empty(t, mockClient.lastEndpoint)
 		assert.Empty(t, mockClient.lastMethod)
 
-		// Verify the repository name remains unchanged in the cache
-		assert.Contains(t, remoteImpl.Repositories(ctx), "old-name")
-		assert.NotContains(t, remoteImpl.Repositories(ctx), "new-name")
+		// Verify the repository was renamed in the cache (dry-run still updates cache for plan consistency)
+		assert.NotContains(t, remoteImpl.Repositories(ctx), "old-name")
+		assert.Contains(t, remoteImpl.Repositories(ctx), "new-name")
 
-		// Verify team references remain unchanged
-		assert.Contains(t, remoteImpl.teamRepos["team1"], "old-name")
-		assert.NotContains(t, remoteImpl.teamRepos["team1"], "new-name")
+		// Verify RefId mapping is updated
+		assert.Equal(t, "new-name", remoteImpl.repositoriesByRefId["R_123"].Name)
+
+		// Verify team references are updated
+		assert.NotContains(t, remoteImpl.teamRepos["team1"], "old-name")
+		assert.Contains(t, remoteImpl.teamRepos["team1"], "new-name")
+		assert.Equal(t, "WRITE", remoteImpl.teamRepos["team1"]["new-name"].Permission)
+	})
+
+	t.Run("happy path: dry run case-only rename updates cache", func(t *testing.T) {
+		mockClient := &RenameRepositoryMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true, true, true)
+		ctx := context.TODO()
+		remoteImpl.Load(ctx, false)
+		mockClient.lastEndpoint = ""
+		mockClient.lastMethod = ""
+		logsCollector := observability.NewLogCollection()
+
+		repo := &GithubRepository{
+			Name:   "old-name",
+			Id:     123,
+			RefId:  "R_123",
+			IsFork: false,
+			BoolProperties: map[string]bool{
+				"archived": false,
+			},
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"old-name": repo,
+		}
+		remoteImpl.repositoriesByRefId = map[string]*GithubRepository{
+			"R_123": repo,
+		}
+		remoteImpl.teamRepos = map[string]map[string]*GithubTeamRepo{
+			"team1": {
+				"old-name": {
+					Name:       "old-name",
+					Permission: "WRITE",
+				},
+			},
+		}
+
+		remoteImpl.RenameRepository(
+			ctx,
+			logsCollector,
+			true, // dryrun
+			"old-name",
+			"Old-Name",
+		)
+
+		assert.False(t, logsCollector.HasErrors())
+		assert.Empty(t, mockClient.lastEndpoint)
+		assert.Empty(t, mockClient.lastMethod)
+		assert.NotContains(t, remoteImpl.Repositories(ctx), "old-name")
+		assert.Contains(t, remoteImpl.Repositories(ctx), "Old-Name")
+		assert.Equal(t, "Old-Name", remoteImpl.repositoriesByRefId["R_123"].Name)
+		assert.Contains(t, remoteImpl.teamRepos["team1"], "Old-Name")
+		assert.Equal(t, "WRITE", remoteImpl.teamRepos["team1"]["Old-Name"].Permission)
 	})
 
 	t.Run("error path: rename to existing repository name", func(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches repository reconciliation and rename behavior (including apply-time GitHub renames for case fixes); scope is narrow and well-tested but renames are operationally sensitive.
> 
> **Overview**
> **v1.9.5** fixes repository reconciliation when GitHub’s repo name differs from the teams definition **only by letter casing**, and makes **`goliac plan`** consistent after renames.
> 
> Before comparing local vs remote repos, the reconciliator now detects a remote repo whose name matches a local name case-insensitively but not exactly, and issues a **`RenameRepository`** to the exact name from YAML (instead of treating it as delete + create). **`RenameRepository`** still skips the GitHub PATCH in dry-run, but **always rekeys** the in-memory cache (`repositories`, `repositoriesByRefId`, `teamRepos`) so later plan steps resolve the repo under the new name—fixing false **repository … not found** after case alignment or YAML **`renameTo`**.
> 
> Tests cover the reconciliator auto-rename path and updated dry-run rename cache behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad63c80c66bd313f8a4e02886d8733eb86f651f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->